### PR TITLE
fix: generate_doksam.py 하드코딩 절대경로 제거 및 README 구조 트리 갱신

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,21 @@ Google Antigravity (`agy`) 환경에서 범용 AI 에이전트를 **'모바일 �
 📦 mobile-web-planner-agent
  ┣ 📂 skills
  ┃ ┗ 📂 mobile_web_planner
- ┃   ┗ 📜 SKILL.md (범용 기획자 페르소나, 워크플로우, 템플릿 정의 파일)
+ ┃   ┣ 📜 SKILL.md (범용 기획자 페르소나, 워크플로우, 템플릿 정의 파일)
+ ┃   ┗ 📂 resources
+ ┃     ┗ 📜 template.html (기획서 HTML/CSS 스켈레톤)
+ ┣ 📂 examples
+ ┃ ┣ 📜 doksam_news_storyboard.html (스킬로 생성한 화면설계서 예시)
+ ┃ ┣ 📜 mobile_news_plan.md (뉴스 앱 기획 예시)
+ ┃ ┗ 📂 images (목업 이미지)
+ ┣ 📜 generate_doksam.py (예시 스토리보드 HTML 생성 스크립트)
  ┗ 📜 README.md
+```
+
+`generate_doksam.py`는 저장소 루트 기준 상대경로로 동작하므로, 클론 후 아래와 같이 바로 실행할 수 있습니다.
+
+```bash
+python generate_doksam.py
 ```
 
 ## 🛠️ 커스터마이징

--- a/generate_doksam.py
+++ b/generate_doksam.py
@@ -1,6 +1,10 @@
 import re
+from pathlib import Path
 
-template_path = '/Users/dok123/.gemini/antigravity/scratch/mobile-web-planner-agent/skills/mobile_web_planner/resources/template.html'
+REPO_ROOT = Path(__file__).resolve().parent
+template_path = REPO_ROOT / 'skills' / 'mobile_web_planner' / 'resources' / 'template.html'
+output_path = REPO_ROOT / 'examples' / 'doksam_news_storyboard.html'
+
 with open(template_path, 'r', encoding='utf-8') as f:
     template = f.read()
 
@@ -247,5 +251,8 @@ html_content = f"""<!DOCTYPE html>
 </html>
 """
 
-with open('/Users/dok123/.gemini/antigravity/scratch/mobile-web-planner-agent/examples/doksam_news_storyboard.html', 'w', encoding='utf-8') as f:
+output_path.parent.mkdir(parents=True, exist_ok=True)
+with open(output_path, 'w', encoding='utf-8') as f:
     f.write(html_content)
+
+print(f'생성 완료: {output_path}')


### PR DESCRIPTION
## 변경 사항

- `generate_doksam.py`: 작성자 로컬 절대경로(`/Users/dok123/.gemini/...`) 하드코딩을 제거하고 `Path(__file__).resolve().parent` 기준 상대경로로 전환. 템플릿 입력·HTML 출력 경로 모두 저장소 기준으로 산출하며, 출력 디렉터리를 자동 생성하고 생성 결과 경로를 출력합니다.
- `README.md`: 구조(Structure) 트리에 `examples/`, `skills/.../resources/`, `generate_doksam.py` 를 추가하고 실행 방법을 명시했습니다.

## 검증

`python3 generate_doksam.py` 실행 시 `FileNotFoundError` 없이 `examples/doksam_news_storyboard.html` 이 정상 생성됨을 확인했습니다.

## 참고 (별도 확인 필요)

스크립트 실행 결과물이 현재 저장소에 커밋된 `examples/doksam_news_storyboard.html` 과 일치하지 않습니다(약 200줄 차이). 커밋된 파일은 스크립트 작성 이후 별도로 갱신된 최신본으로 판단되어, 본 PR 에서는 재생성 결과를 반영하지 않고 기존 파일을 그대로 유지했습니다.

Closes #1
