### PR TITLE
fix: IA mermaid 다이어그램이 슬라이드를 채우도록 크기 규칙 추가 (#7)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -123,6 +123,29 @@ body {
   border: 1px solid #aaa;
   padding: 40px;
   overflow-y: auto;
+  position: relative; /* .mermaid 를 absolute 로 채우기 위한 기준 */
+}
+
+/* Mermaid 다이어그램 (IA 슬라이드)
+   mermaid.js 는 생성한 SVG 에 인라인 max-width 를 박아 자체 크기에 가둔다.
+   또 .mermaid 를 flex item 으로 두면 shrink-to-fit 되어 300px 남짓에 머문다.
+   absolute + inset:0 으로 폭·높이를 확정해 주어야 SVG 의 max-height:100% 가
+   해석되고, 비율을 유지한 채 슬라이드를 채운다. 퍼센트 높이만 주면
+   flex 안에서 순환 참조가 생겨 부모가 부풀어 슬라이드 레이아웃이 깨진다.
+   mermaid 가 유일한 자식일 때만 적용한다(텍스트와 혼용 시 겹침 방지). */
+.ppt-body-full > .mermaid:only-child {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mermaid > svg {
+  max-width: 100% !important; /* 인라인 max-width 를 이겨야 한다 */
+  max-height: 100%;
+  width: auto;
+  height: auto;
 }
 
 /* Left Wireframe Canvas */

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -68,7 +68,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `ppt-footer` | 하단 주황 푸터 바 |
 | `<code>` (클래스 아님 · 엘리먼트) | 디자인 시스템 컴포넌트명 인라인 표기 |
 | `icon` | Phosphor 인라인 SVG 아이콘 |
-| `mermaid` | IA 다이어그램. CSS 정의 없음 — mermaid.js 가 렌더 |
+| `mermaid` | IA 다이어그램. 도형은 mermaid.js 가 렌더하고, 슬라이드를 채우는 크기 규칙만 템플릿이 갖는다. `ppt-body-full` 의 **유일한 자식**일 때 크기 규칙이 적용되므로 텍스트와 섞지 않는다 |
 
 # Icons
 

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -122,6 +122,29 @@ body {
   border: 1px solid #aaa;
   padding: 40px;
   overflow-y: auto;
+  position: relative; /* .mermaid 를 absolute 로 채우기 위한 기준 */
+}
+
+/* Mermaid 다이어그램 (IA 슬라이드)
+   mermaid.js 는 생성한 SVG 에 인라인 max-width 를 박아 자체 크기에 가둔다.
+   또 .mermaid 를 flex item 으로 두면 shrink-to-fit 되어 300px 남짓에 머문다.
+   absolute + inset:0 으로 폭·높이를 확정해 주어야 SVG 의 max-height:100% 가
+   해석되고, 비율을 유지한 채 슬라이드를 채운다. 퍼센트 높이만 주면
+   flex 안에서 순환 참조가 생겨 부모가 부풀어 슬라이드 레이아웃이 깨진다.
+   mermaid 가 유일한 자식일 때만 적용한다(텍스트와 혼용 시 겹침 방지). */
+.ppt-body-full > .mermaid:only-child {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mermaid > svg {
+  max-width: 100% !important; /* 인라인 max-width 를 이겨야 한다 */
+  max-height: 100%;
+  width: auto;
+  height: auto;
 }
 
 /* Left Wireframe Canvas */


### PR DESCRIPTION
## 요약

IA 슬라이드의 mermaid 다이어그램이 콘텐츠 영역의 22%만 차지해 노드 텍스트를 읽기 어려웠던 문제를 고친다.

Closes #7

## 원인 (브라우저 실측)

`1400x788` 슬라이드에서 `.ppt-body-full` 은 `1374x674` 인데, `.mermaid` div 는 `300x267` 에 머물렀다.

두 가지가 겹쳐 작동한다.

1. **mermaid.js 가 SVG 에 인라인 `max-width` 를 박는다** — `style="max-width: 608.9px"`. 스타일시트 규칙은 인라인 스타일을 이기지 못하므로 `!important` 없이는 풀 수 없다.
2. **`.mermaid` 가 flex item 이라 shrink-to-fit 된다** — SVG 의 `width="100%"` 가 자기 부모 폭에 대해 해석되는데 그 부모가 내용 기반으로 줄어드는 순환이 되어 300px 남짓에 정착한다.

## 채택하지 않은 방안

`.mermaid { width:100%; height:100% }` 로 퍼센트 높이를 주는 방식을 먼저 시험했다. SVG 는 22%x39% → 94%x93% 로 커졌지만 **컨테이너 높이가 674px → 1214px 로 부풀어** 슬라이드 레이아웃이 깨졌다. flex 컨텍스트에서 퍼센트 높이가 순환 참조를 만든다.

## 채택한 방안

`.ppt-body-full` 에 `position: relative` 를 주고, mermaid 가 유일한 자식일 때 `position:absolute; inset:0` 으로 폭과 높이를 **확정**한다. 확정된 높이가 있어야 SVG 의 `max-height:100%` 가 해석되고, `width:auto; height:auto` 로 비율을 유지한 채 영역에 맞춰진다.

```css
.ppt-body-full { position: relative; }
.ppt-body-full > .mermaid:only-child {
  position: absolute; inset: 0; margin: 0;
  display: flex; align-items: center; justify-content: center;
}
.mermaid > svg {
  max-width: 100% !important;
  max-height: 100%;
  width: auto; height: auto;
}
```

`:only-child` 로 좁힌 이유는 absolute 가 흐름에서 빠지므로, 텍스트와 mermaid 를 같은 `ppt-body-full` 에 섞으면 겹치기 때문이다. 이 조건을 `SKILL.md` 에도 명시했다.

## 검증

브라우저 실측. 두 다이어그램 종류 모두 확인했다.

| 다이어그램 | 이전 | 이후 | SVG 크기 | 오버플로 |
|---|---|---|---|---|
| `mindmap` (예시 문서) | 22% x 39% | **56% x 100%** | 300x263 → 766x671 | 없음 |
| `flowchart` (테니스클럽 문서) | 22% x 14% | **100% x 64%** | 300x94 → 1372x432 | 없음 |

슬라이드 높이는 `788 == 1400 x 9/16` 로 16:9 를 그대로 유지하며, 컨테이너 크기(`1374x674`)도 변하지 않는다. 채움 비율이 100% 에 못 미치는 축은 다이어그램 자체의 종횡비 때문이며, 짧은 축이 꽉 차는 것이 올바른 동작이다.

```
$ python3 generate_doksam.py
생성 완료: examples/doksam_news_storyboard.html (슬라이드 7장)

$ git diff --exit-code examples/
(clean — 재생성 불변식 성립)

$ python3 -m unittest discover -s tests
Ran 24 tests in 0.002s
OK

$ ./tests/test_install.sh
pass=30 fail=0
```

## 함께 정정한 것

`SKILL.md` 의 Class Quick Reference 가 `mermaid` 를 "CSS 정의 없음" 이라고 서술했는데, 이제 크기 규칙을 갖게 되어 사실과 달라졌다. 서술을 정정하고 `:only-child` 조건을 명시했다.

`generate_doksam.py` 의 `WHITELIST` 는 그대로 두었다. `mermaid` 가 이제 `defined_classes` 에 포함되므로 화이트리스트 없이도 검증을 통과하지만, 남겨두어도 동작에 영향이 없고 "mermaid 는 CSS 없이도 유효하다" 는 원래 의도를 보존한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
