### PR TITLE
fix: pointer-badge 잘림 해소 — mock-body 에 배지 gutter 확보 (#6)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -224,7 +224,12 @@ body {
   justify-content: space-between;
   border-bottom: 1px solid #e2e8f0;
 }
-.mock-body { padding: 16px; flex: 1; background: #fff; overflow-y: auto; }
+/* padding-left 28px 는 pointer-badge 전용 gutter 다.
+   배지를 left:-12px 로 프레임 밖에 두면 mock-body(overflow-y:auto 이므로
+   overflow-x 도 auto 로 계산된다) 와 mock-screen(overflow:hidden) 이
+   절반을 잘라낸다. 배지를 left:2px 로 이 여백 안에 두면 온전히 보이고
+   콘텐츠(28px 부터 시작)와 겹치지도 않는다. 배지 폭 24px + 여유 4px. */
+.mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
 .mock-footer {
   border-top: 1px solid #e2e8f0;
   display: flex;
@@ -450,20 +455,20 @@ mindmap
             </div>
             <div class="mock-body" style="position:relative;">
 
-              <span class="pointer-badge" style="position:absolute; top:20px; left:-12px; z-index:10;">1</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
               <div style="background:#ea580c; border-radius:4px; padding:16px; margin-bottom:16px; color:#fff;">
                 <div style="font-size:10px; font-weight:800; margin-bottom:6px;">BREAKING NEWS</div>
                 <div style="font-size:15px; font-weight:700;">글로벌 혁신 AI, 세상을 바꾸다</div>
               </div>
 
-              <span class="pointer-badge" style="position:absolute; top:130px; left:-12px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:130px; left:2px; z-index:10;">2</span>
               <div style="display:flex; gap:16px; border-bottom:1px solid #ccc; padding-bottom:8px; margin-bottom:16px;">
                 <div style="font-size:13px; font-weight:800; color:#ea580c; border-bottom:2px solid #ea580c; padding-bottom:6px;">Top Stories</div>
                 <div style="font-size:13px; font-weight:500; color:#555;">World</div>
                 <div style="font-size:13px; font-weight:500; color:#555;">Business</div>
               </div>
 
-              <span class="pointer-badge" style="position:absolute; top:190px; left:-12px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; top:190px; left:2px; z-index:10;">3</span>
               <div style="display:flex; gap:12px; align-items:flex-start; padding-bottom:16px; border-bottom:1px solid #eee;">
                 <div style="width:72px; height:72px; background:#ddd; border-radius:8px;"></div>
                 <div style="flex:1;">
@@ -532,7 +537,7 @@ mindmap
           <div class="mock-screen" style="position:relative;">
             <div class="mock-status"></div>
 
-            <span class="pointer-badge" style="position:absolute; top:20px; left:-12px; z-index:10;">1</span>
+            <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
             <div style="height:160px; background:#ddd; position:relative;">
               <div class="mock-header" style="background:transparent; border:none; position:absolute; top:0; width:100%;">
                 <span style="color:#111; font-weight:800; background:rgba(255,255,255,0.8); padding:4px 8px; border-radius:4px;">&lsaquo;</span>
@@ -540,16 +545,16 @@ mindmap
               </div>
             </div>
 
-            <div class="mock-body" style="background:#fff; border-radius:16px 16px 0 0; margin-top:-16px; position:relative; z-index:2; padding:24px 16px;">
+            <div class="mock-body" style="background:#fff; border-radius:16px 16px 0 0; margin-top:-16px; position:relative; z-index:2; padding:24px 16px 24px 28px;">
               <div style="font-size:12px; color:#ea580c; font-weight:800; margin-bottom:8px;">TECH</div>
               <div style="font-size:20px; font-weight:800; color:#111; line-height:1.4; margin-bottom:16px;">새로운 모바일 기획 에이전트 출시, UX/UI 패러다임 전환</div>
 
-              <span class="pointer-badge" style="position:absolute; top:120px; left:-12px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:120px; left:2px; z-index:10;">2</span>
               <div style="font-size:14px; color:#333; line-height:1.6; margin-bottom:30px;">
                 새롭게 출시된 모바일웹 플래너 에이전트는 기획자의 의도를 파악해 완결된 스토리보드를 구축합니다.
               </div>
 
-              <span class="pointer-badge" style="position:absolute; bottom:20px; left:-12px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; bottom:20px; left:2px; z-index:10;">3</span>
               <div style="display:flex; justify-content:center; gap:16px;">
                 <div style="flex:1; padding:12px 0; border:1px solid #ccc; border-radius:8px; display:flex; justify-content:center; align-items:center; gap:8px; font-size:13px; font-weight:700;">
                   <svg class="icon" viewBox="0 0 256 256"><path d="M240,88.23a54.43,54.43,0,0,1-16,37L189.25,160a54.27,54.27,0,0,1-38.63,16h-.05A54.63,54.63,0,0,1,96,119.84a8,8,0,0,1,16,.45A38.62,38.62,0,0,0,150.58,160h0a38.39,38.39,0,0,0,27.31-11.31l34.75-34.75a38.63,38.63,0,0,0-54.63-54.63l-11,11A8,8,0,0,1,135.7,59l11-11A54.65,54.65,0,0,1,224,48,54.86,54.86,0,0,1,240,88.23ZM109,185.66l-11,11A38.41,38.41,0,0,1,70.6,208h0a38.63,38.63,0,0,1-27.29-65.94L78,107.31A38.63,38.63,0,0,1,144,135.71a8,8,0,0,0,16,.45A54.86,54.86,0,0,0,144,96a54.65,54.65,0,0,0-77.27,0L32,130.75A54.62,54.62,0,0,0,70.56,224h0a54.28,54.28,0,0,0,38.64-16l11-11A8,8,0,0,0,109,185.66Z"/></svg> Copy Link

--- a/generate_doksam.py
+++ b/generate_doksam.py
@@ -267,20 +267,20 @@ def _main_home() -> str:
             </div>
             <div class="mock-body" style="position:relative;">
 
-              <span class="pointer-badge" style="position:absolute; top:20px; left:-12px; z-index:10;">1</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
               <div style="background:#ea580c; border-radius:4px; padding:16px; margin-bottom:16px; color:#fff;">
                 <div style="font-size:10px; font-weight:800; margin-bottom:6px;">BREAKING NEWS</div>
                 <div style="font-size:15px; font-weight:700;">글로벌 혁신 AI, 세상을 바꾸다</div>
               </div>
 
-              <span class="pointer-badge" style="position:absolute; top:130px; left:-12px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:130px; left:2px; z-index:10;">2</span>
               <div style="display:flex; gap:16px; border-bottom:1px solid #ccc; padding-bottom:8px; margin-bottom:16px;">
                 <div style="font-size:13px; font-weight:800; color:#ea580c; border-bottom:2px solid #ea580c; padding-bottom:6px;">Top Stories</div>
                 <div style="font-size:13px; font-weight:500; color:#555;">World</div>
                 <div style="font-size:13px; font-weight:500; color:#555;">Business</div>
               </div>
 
-              <span class="pointer-badge" style="position:absolute; top:190px; left:-12px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; top:190px; left:2px; z-index:10;">3</span>
               <div style="display:flex; gap:12px; align-items:flex-start; padding-bottom:16px; border-bottom:1px solid #eee;">
                 <div style="width:72px; height:72px; background:#ddd; border-radius:8px;"></div>
                 <div style="flex:1;">
@@ -340,7 +340,7 @@ def _article_detail() -> str:
           <div class="mock-screen" style="position:relative;">
             <div class="mock-status"></div>
 
-            <span class="pointer-badge" style="position:absolute; top:20px; left:-12px; z-index:10;">1</span>
+            <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
             <div style="height:160px; background:#ddd; position:relative;">
               <div class="mock-header" style="background:transparent; border:none; position:absolute; top:0; width:100%;">
                 <span style="color:#111; font-weight:800; background:rgba(255,255,255,0.8); padding:4px 8px; border-radius:4px;">&lsaquo;</span>
@@ -348,16 +348,16 @@ def _article_detail() -> str:
               </div>
             </div>
 
-            <div class="mock-body" style="background:#fff; border-radius:16px 16px 0 0; margin-top:-16px; position:relative; z-index:2; padding:24px 16px;">
+            <div class="mock-body" style="background:#fff; border-radius:16px 16px 0 0; margin-top:-16px; position:relative; z-index:2; padding:24px 16px 24px 28px;">
               <div style="font-size:12px; color:#ea580c; font-weight:800; margin-bottom:8px;">TECH</div>
               <div style="font-size:20px; font-weight:800; color:#111; line-height:1.4; margin-bottom:16px;">새로운 모바일 기획 에이전트 출시, UX/UI 패러다임 전환</div>
 
-              <span class="pointer-badge" style="position:absolute; top:120px; left:-12px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:120px; left:2px; z-index:10;">2</span>
               <div style="font-size:14px; color:#333; line-height:1.6; margin-bottom:30px;">
                 새롭게 출시된 모바일웹 플래너 에이전트는 기획자의 의도를 파악해 완결된 스토리보드를 구축합니다.
               </div>
 
-              <span class="pointer-badge" style="position:absolute; bottom:20px; left:-12px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; bottom:20px; left:2px; z-index:10;">3</span>
               <div style="display:flex; justify-content:center; gap:16px;">
                 <div style="flex:1; padding:12px 0; border:1px solid #ccc; border-radius:8px; display:flex; justify-content:center; align-items:center; gap:8px; font-size:13px; font-weight:700;">
                   {ICON_LINK} Copy Link

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -35,7 +35,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 **화면 상세는 04 IA 에 정의한 모든 주요 화면을 빠짐없이 각각 별도 슬라이드로 만든다.** 작성을 마치기 전에 스스로 점검한다: IA 의 주요 화면 수와 `06.x` 슬라이드 수가 같은가. 다르면 빠진 화면을 추가한다.
 
-화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 번호(1, 2, 3...)와 설명 리스트의 `desc-num` 기호(①, ②, ③...)를 **1:1 로 대응**시킨다.
+화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 번호(1, 2, 3...)와 설명 리스트의 `desc-num` 기호(①, ②, ③...)를 **1:1 로 대응**시킨다. 설명 항목 수와 배지 수가 같아야 한다 — `mock-footer` 처럼 `mock-body` 밖의 요소를 설명하는 항목도 배지를 빠뜨리지 않는다(아래 마크업 참고).
+
+`pointer-badge` 는 `left:2px` 로 둔다. `mock-body` 의 좌측 28px 여백이 배지 자리다. **`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 28px 이상으로 유지한다** — 그러지 않으면 배지가 본문 텍스트를 가린다.
 
 # Class Quick Reference
 
@@ -57,7 +59,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `ppt-desc-body` | 설명 패널 본문 |
 | `desc-list` | 설명 리스트 (`ul`) |
 | `desc-num` | 설명 항목 번호 (①②③) |
-| `pointer-badge` | 목업 위 주황 번호 배지. `desc-num` 과 1:1 대응 |
+| `pointer-badge` | 목업 위 주황 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 의 좌측 28px 여백이 배지 자리다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
 | `mock` | 모바일 목업 외곽 프레임 |
 | `mock-screen` | 목업 화면 |
 | `mock-status` | 목업 상태바 |
@@ -105,10 +107,13 @@ description: Use when the user asks for a mobile web or app screen design docume
           <div class="mock-status"></div>
           <div class="mock-header">헤더영역</div>
           <div class="mock-body" style="position:relative;">
-            <span class="pointer-badge" style="position:absolute; top:20px; left:-12px; z-index:10;">1</span>
+            <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
             <!-- 목업 내용. 세부 스타일은 인라인 style 로 -->
           </div>
-          <div class="mock-footer">
+          <div class="mock-footer" style="position:relative;">
+            <!-- mock-footer 처럼 mock-body 밖의 요소를 설명할 때는
+                 그 요소에 position:relative 를 주고 배지를 얹는다 -->
+            <span class="pointer-badge" style="position:absolute; top:9px; left:2px; z-index:10;">4</span>
             <div class="mock-tab active">Home</div>
             <div class="mock-tab">Search</div>
           </div>

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -223,7 +223,12 @@ body {
   justify-content: space-between;
   border-bottom: 1px solid #e2e8f0;
 }
-.mock-body { padding: 16px; flex: 1; background: #fff; overflow-y: auto; }
+/* padding-left 28px 는 pointer-badge 전용 gutter 다.
+   배지를 left:-12px 로 프레임 밖에 두면 mock-body(overflow-y:auto 이므로
+   overflow-x 도 auto 로 계산된다) 와 mock-screen(overflow:hidden) 이
+   절반을 잘라낸다. 배지를 left:2px 로 이 여백 안에 두면 온전히 보이고
+   콘텐츠(28px 부터 시작)와 겹치지도 않는다. 배지 폭 24px + 여유 4px. */
+.mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
 .mock-footer {
   border-top: 1px solid #e2e8f0;
   display: flex;


### PR DESCRIPTION
## 요약

목업 위 `pointer-badge` 가 좌측 경계에서 정확히 절반 잘리던 문제를 고친다. 배지와 설명 리스트의 `desc-num`(①②③) 1:1 대응은 화면설계서를 읽는 핵심 문법이므로, 배지가 잘리면 그 대응이 훼손된다.

Closes #6

## 원인 (브라우저 실측)

`SKILL.md` 마크업 예시가 배지를 `left:-12px` 로 프레임 밖에 내밀었다. 배지 폭이 24px 이므로 절반이 부모 밖으로 나가는데, 두 조상이 그것을 잘라낸다.

- `.mock-body` — `overflow-y: auto` 이므로 CSS 상 `overflow-x` 가 `visible` 에서 `auto` 로 **계산**된다. 한 축만 non-visible 로 둘 수 없다.
- `.mock-screen` — `overflow: hidden`

예시 문서의 배지 6개를 측정하니 **전부 정확히 50%** 만 보였다.

브랜치 이전(`9fe89c9`)과 좌표·`overflow` 설정이 동일하므로 회귀는 아니다. 그러나 `SKILL.md` 가 같은 좌표를 예시로 전파하므로 이 스킬이 만드는 모든 기획서에서 재현된다.

## 채택하지 않은 방안

**배지를 `.mock` 직하위로 옮기기** — `.mock` 은 `position:relative` 이고 `overflow` 가 없어 `left:-12px` 가 100% 보인다(실측 확인, 패널 좌측까지 347px 여유). 실무 PPT 관례(배지가 프레임 밖에 걸침)에도 맞다. 그러나 배지의 `top` 을 `mock-body` 가 아니라 `mock` 기준으로 계산해야 해서, 상태바 20px + 헤더 약 57px 만큼 오프셋이 어긋난다. 에이전트가 좌표를 틀리기 쉬워 채택하지 않았다.

**`overflow: visible` 로 풀기** — `mock-screen` 의 `overflow:hidden` 은 목업 콘텐츠가 프레임을 넘지 않게 하는 장치이고, `mock-body` 는 한 축만 풀 수 없다. 세로 클리핑을 잃는 대가가 크다.

## 채택한 방안 — 배지 전용 gutter

`.mock-body` 의 `padding-left` 를 16px → **28px** 로 늘려 배지 자리를 만들고, 배지를 `left:2px` 로 그 안에 넣는다. 배지 폭 24px + 여유 4px.

```css
.mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
```

구조 변경이 없고, 배지의 `top` 좌표를 `mock-body` 기준으로 그대로 쓸 수 있어 작성 방식이 바뀌지 않는다.

## 함께 해결한 것 두 가지

**1. 인라인 `padding` 이 gutter 를 덮어쓰는 함정.** 예시 `06.2` 가 `mock-body` 에 인라인 `padding:24px 16px` 를 주고 있어, 템플릿 gutter 가 무효화되고 배지가 본문 텍스트를 가렸다(브라우저에서 "새롭게" 의 "새" 가 배지에 덮임). 생성기를 `padding:24px 16px 24px 28px` 로 고치고, `SKILL.md` 에 "`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 28px 이상 유지" 를 명시했다.

**2. `mock-body` 밖 요소에 배지를 다는 방법이 없었다.** `mock-footer`(하단 탭 바)를 설명하는 항목에 배지를 달 자리가 없어 1:1 대응이 깨지는 사례가 있었다. 해당 요소에 `position:relative` 를 주고 배지를 얹는 방법을 마크업 예시에 추가했다.

## 검증

브라우저 실측 (예시 문서 배지 6개):

| 측정 | 이전 | 이후 |
|---|---|---|
| 배지 가시 폭 | **50%** (6개 전부) | **100%** (X축·Y축 모두) |
| 본문 겹침 | `06.2` 에서 텍스트 가림 | `mock-body` 배지 5개 전부 없음 (배지 우측끝 23px < padding-left 28px) |

`mock-screen` 직하위 배지 1개는 헤더 이미지 위에 놓여 가릴 텍스트가 없다.

```
$ python3 generate_doksam.py
생성 완료: examples/doksam_news_storyboard.html (슬라이드 7장)

$ git diff --exit-code examples/
(clean — 재생성 불변식 성립)

$ python3 -m unittest discover -s tests
Ran 24 tests in 0.002s
OK

$ ./tests/test_install.sh
pass=30 fail=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
