### PR TITLE
feat: 상단 메타 바 추가 — 화면 위치(Location) 표기 (#17)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -95,6 +95,38 @@ body {
   font-size: 14px;
 }
 
+/* 메타 바 — 화면 상세(06.x) 슬라이드의 상단 바 아래 한 줄.
+   실무 화면설계서의 헤더 표에서 Location(화면 위치 경로)에 해당한다.
+   이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면 맥락이 잡힌다.
+   높이 28px 만큼 ppt-content 가 줄지만, 목업(zoom 0.9 기준 540px)은
+   남는 높이 안에 그대로 들어간다. */
+.ppt-meta-bar {
+  height: 28px;
+  background: #f4f4f5;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #555555;
+  flex: none;
+}
+.ppt-meta-label {
+  background: #d4d4d8;
+  color: #3f3f46;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  font-weight: 700;
+  flex: none;
+}
+.ppt-meta-value {
+  padding: 0 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Bottom Footer */
 .ppt-footer {
   height: 40px;
@@ -284,8 +316,9 @@ body {
 
    가용 폭 980px = 슬라이드 1400 - 테두리 2 - ppt-content padding 24
                    - desc panel 380 - gap 12 - wireframe 테두리 2
-   가용 높이 671.5px = 787.5(16:9) - 테두리 2 - top bar 48 - footer 40
-                       - ppt-content padding 24 - wireframe 테두리 2
+   가용 높이 643.5px = 787.5(16:9) - 테두리 2 - top bar 48 - meta bar 28
+                       - footer 40 - ppt-content padding 24 - wireframe 테두리 2
+                       (box-sizing:border-box 이므로 각 테두리는 height 에 포함)
    2~3개: 320*0.9 = 288    -> 3*288 + 2*24(gap)   = 912   <= 980
    4개  : 320*0.68 = 217.6 -> 4*217.6 + 3*24(gap) = 942.4 <= 980
    5개 이상은 슬라이드를 나눈다. */
@@ -515,6 +548,10 @@ mindmap
       <div class="ppt-top-title">Main Home</div>
       <div class="ppt-top-proj">덕삼뉴스</div>
     </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈</div>
+    </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
         <div class="mock">
@@ -601,6 +638,10 @@ mindmap
       <div class="ppt-top-no">NO. 06.2</div>
       <div class="ppt-top-title">Article Detail</div>
       <div class="ppt-top-proj">덕삼뉴스</div>
+    </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 > 기사 상세</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">

--- a/generate_doksam.py
+++ b/generate_doksam.py
@@ -101,15 +101,25 @@ TH = 'style="padding:12px; border:1px solid #ddd;"'
 TD = 'style="padding:12px; border:1px solid #ddd;"'
 
 
-def _slide(no: str, title: str, body: str) -> str:
-    """슬라이드 1장을 조립한다. body 는 ppt-content 내부 마크업."""
+def _slide(no: str, title: str, body: str, location: str = "") -> str:
+    """슬라이드 1장을 조립한다.
+
+    body 는 ppt-content 내부 마크업. location 을 주면 상단 바 아래에
+    메타 줄(화면 위치)을 넣는다 — 화면 상세(06.x) 에만 해당한다.
+    """
+    meta = ""
+    if location:
+        meta = (f'\n    <div class="ppt-meta-bar">'
+                f'\n      <div class="ppt-meta-label">Location</div>'
+                f'\n      <div class="ppt-meta-value">{location}</div>'
+                f'\n    </div>')
     return f"""
   <div class="ppt-slide">
     <div class="ppt-top-bar">
       <div class="ppt-top-no">NO. {no}</div>
       <div class="ppt-top-title">{title}</div>
       <div class="ppt-top-proj">{PROJECT_NAME}</div>
-    </div>
+    </div>{meta}
     <div class="ppt-content">
 {body}
     </div>
@@ -331,7 +341,7 @@ def _main_home() -> str:
           </ul>
         </div>
       </div>"""
-    return _slide("06.1", "Main Home", body)
+    return _slide("06.1", "Main Home", body, "홈")
 
 
 def _article_detail() -> str:
@@ -401,7 +411,7 @@ def _article_detail() -> str:
           </ul>
         </div>
       </div>"""
-    return _slide("06.2", "Article Detail", body)
+    return _slide("06.2", "Article Detail", body, "홈 > 기사 상세")
 
 
 def build_html(styles: str) -> str:

--- a/scripts/build_multimock_probe.py
+++ b/scripts/build_multimock_probe.py
@@ -52,6 +52,10 @@ def slide(no, title, mocks):
       <div class="ppt-top-title">{title}</div>
       <div class="ppt-top-proj">PROBE</div>
     </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
+    </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
 {nl.join(mocks)}
@@ -93,7 +97,7 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
   var n = +slide.dataset.mockcount, tag='['+n+'-mock] ';
   var wf = slide.querySelector('.ppt-wireframe'), wi = inner(wf);
   chk(tag+'ppt-wireframe content width', wi.right-wi.left, 980, 1.5);
-  chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 671.5, 1.5);
+  chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 643.5, 1.5);
   chk(tag+'ppt-wireframe no h-overflow (scrollWidth<=clientWidth)', wf.scrollWidth<=wf.clientWidth, true);
   chk(tag+'ppt-wireframe no v-overflow (scrollHeight<=clientHeight)', wf.scrollHeight<=wf.clientHeight, true);
   var mocks=[].slice.call(slide.querySelectorAll('.mock'));

--- a/scripts/multimock-probe.html
+++ b/scripts/multimock-probe.html
@@ -78,6 +78,38 @@ body {
   font-size: 14px;
 }
 
+/* 메타 바 — 화면 상세(06.x) 슬라이드의 상단 바 아래 한 줄.
+   실무 화면설계서의 헤더 표에서 Location(화면 위치 경로)에 해당한다.
+   이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면 맥락이 잡힌다.
+   높이 28px 만큼 ppt-content 가 줄지만, 목업(zoom 0.9 기준 540px)은
+   남는 높이 안에 그대로 들어간다. */
+.ppt-meta-bar {
+  height: 28px;
+  background: #f4f4f5;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #555555;
+  flex: none;
+}
+.ppt-meta-label {
+  background: #d4d4d8;
+  color: #3f3f46;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  font-weight: 700;
+  flex: none;
+}
+.ppt-meta-value {
+  padding: 0 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Bottom Footer */
 .ppt-footer {
   height: 40px;
@@ -325,6 +357,10 @@ code {
       <div class="ppt-top-title">1 mock (regression baseline, no caption)</div>
       <div class="ppt-top-proj">PROBE</div>
     </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
+    </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
         <div class="mock">
@@ -359,6 +395,10 @@ code {
       <div class="ppt-top-no">NO. 06.2</div>
       <div class="ppt-top-title">2 mocks (zoom 0.9)</div>
       <div class="ppt-top-proj">PROBE</div>
+    </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
@@ -411,6 +451,10 @@ code {
       <div class="ppt-top-no">NO. 06.3</div>
       <div class="ppt-top-title">3 mocks (zoom 0.9)</div>
       <div class="ppt-top-proj">PROBE</div>
+    </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
@@ -478,6 +522,10 @@ code {
       <div class="ppt-top-no">NO. 06.4</div>
       <div class="ppt-top-title">4 mocks (zoom 0.68)</div>
       <div class="ppt-top-proj">PROBE</div>
+    </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
@@ -575,7 +623,7 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
   var n = +slide.dataset.mockcount, tag='['+n+'-mock] ';
   var wf = slide.querySelector('.ppt-wireframe'), wi = inner(wf);
   chk(tag+'ppt-wireframe content width', wi.right-wi.left, 980, 1.5);
-  chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 671.5, 1.5);
+  chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 643.5, 1.5);
   chk(tag+'ppt-wireframe no h-overflow (scrollWidth<=clientWidth)', wf.scrollWidth<=wf.clientWidth, true);
   chk(tag+'ppt-wireframe no v-overflow (scrollHeight<=clientHeight)', wf.scrollHeight<=wf.clientHeight, true);
   var mocks=[].slice.call(slide.querySelectorAll('.mock'));

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -41,6 +41,8 @@ description: Use when the user asks for a mobile web or app screen design docume
 - 나열 순서가 정보구조상 부자연스러워도 순서를 바꾸지 않는다. 대신 `04 IA` 다이어그램의 노드 배열을 `06.x` 순서에 맞춘다.
 - `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `06.x` 슬라이드 순서 **세 곳이 모두 같아야 한다.**
 
+**`06.x` 슬라이드에는 `ppt-meta-bar` 로 화면 위치를 적는다.** 진입점부터 그 화면까지의 경로를 `>` 로 잇는다 — 예: `홈 > 게시판 > 글 상세`. `04 IA` 의 연결 관계에서 그대로 끌어온다. 이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면이 앱 어디에 있는지 알 수 있다. `01`~`05` 슬라이드에는 넣지 않는다 — 화면이 아니므로 위치가 없다.
+
 화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 번호(1, 2, 3...)와 설명 리스트의 `desc-num` 기호(①, ②, ③...)를 **1:1 로 대응**시킨다. 설명 항목 수와 배지 수가 같아야 한다 — `mock-footer` 처럼 `mock-body` 밖의 요소를 설명하는 항목도 배지를 빠뜨리지 않는다(아래 마크업 참고).
 
 `pointer-badge` 는 `left:2px` 로 둔다. `mock-body` 의 좌측 28px 여백이 배지 자리다. **`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 28px 이상으로 유지한다** — 그러지 않으면 배지가 본문 텍스트를 가린다.
@@ -83,6 +85,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `ppt-top-no` | 상단 바 좌측 회색 번호 블록 (`NO. 01`) |
 | `ppt-top-title` | 상단 바 제목 |
 | `ppt-top-proj` | 상단 바 우측 프로젝트명 |
+| `ppt-meta-bar` | 상단 바 아래 메타 줄. **화면 상세(`06.x`)에만** 둔다 |
+| `ppt-meta-label` | 메타 줄의 회색 라벨 칸 (`Location`) |
+| `ppt-meta-value` | 메타 줄의 값 칸. 넘치면 말줄임 |
 | `ppt-content` | 중간 영역 컨테이너 |
 | `ppt-body-full` | 좌우 분할하지 않는 통짜 콘텐츠 (01~05) |
 | `ppt-wireframe` | 좌측 와이어프레임 패널 (06.x). **`mock` 을 1개 이상(최대 4개) 배치할 수 있다** — 개수에 따라 축소율과 간격을 템플릿이 자동 조절한다 |
@@ -106,7 +111,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 ## 저장 전 자체 점검
 
-파일을 저장하기 전에 완성된 마크업을 훑으며 아래 여섯 가지를 센다. 어긋나는 항목이 있으면 저장 전에 고친다. 템플릿의 CSS 를 그대로 옮기지 않고 다시 썼더라도 이 점검은 그대로 수행한다.
+파일을 저장하기 전에 완성된 마크업을 훑으며 아래 일곱 가지를 센다. 어긋나는 항목이 있으면 저장 전에 고친다. 템플릿의 CSS 를 그대로 옮기지 않고 다시 썼더라도 이 점검은 그대로 수행한다.
 
 1. **클래스** — 산출물에 등장하는 `class` 값을 전부 모아 Class Quick Reference 표와 대조한다. 표에 없는 이름이 하나라도 있으면 그 `class` 를 지우고 같은 효과를 인라인 `style` 로 옮긴다. 표에 없는 클래스는 CSS 정의가 없어 아무 스타일도 적용되지 않는다.
 2. **이모지** — 이모지 개수가 0 인가. 하나라도 있으면 Phosphor 인라인 SVG 아이콘으로 바꾸거나 지운다. `‹` `⋮` 같은 타이포그래피 문자는 이모지가 아니므로 그대로 둔다.
@@ -114,6 +119,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 4. **배지 개수** — 슬라이드마다 `pointer-badge` 개수와 `desc-num` 개수가 같은가. 다르면 모자란 쪽을 채워 1:1 로 맞춘다.
 5. **화면 순서** — `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `06.x` 슬라이드 순서 세 곳이 같은가. 그리고 그 순서가 사용자가 기능을 나열한 순서와 같은가(진입 화면은 `06.1`). 다르면 사용자 나열 순서를 기준으로 세 곳을 함께 맞춘다.
 6. **목업 개수** — `06.x` 마다 목업 트리거 표(위 `## 목업 여러 개 배치`)를 대조한다. 트리거에 해당하는데 `mock` 이 1개면 2개로 늘리고 `mock-caption` 을 붙인다. 해당하지 않는데 2개면 1개로 줄인다.
+7. **화면 위치** — `06.x` 마다 `ppt-meta-bar` 가 있고 값이 `04 IA` 의 경로와 맞는가. `01`~`05` 에는 없어야 한다.
 
 # Icons
 
@@ -140,6 +146,11 @@ description: Use when the user asks for a mobile web or app screen design docume
     <div class="ppt-top-no">NO. 06.1</div>
     <div class="ppt-top-title">Main Home</div>
     <div class="ppt-top-proj">{{PROJECT_NAME}}</div>
+  </div>
+
+  <div class="ppt-meta-bar">
+    <div class="ppt-meta-label">Location</div>
+    <div class="ppt-meta-value">홈</div>
   </div>
 
   <div class="ppt-content">

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -94,6 +94,38 @@ body {
   font-size: 14px;
 }
 
+/* 메타 바 — 화면 상세(06.x) 슬라이드의 상단 바 아래 한 줄.
+   실무 화면설계서의 헤더 표에서 Location(화면 위치 경로)에 해당한다.
+   이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면 맥락이 잡힌다.
+   높이 28px 만큼 ppt-content 가 줄지만, 목업(zoom 0.9 기준 540px)은
+   남는 높이 안에 그대로 들어간다. */
+.ppt-meta-bar {
+  height: 28px;
+  background: #f4f4f5;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #555555;
+  flex: none;
+}
+.ppt-meta-label {
+  background: #d4d4d8;
+  color: #3f3f46;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  font-weight: 700;
+  flex: none;
+}
+.ppt-meta-value {
+  padding: 0 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Bottom Footer */
 .ppt-footer {
   height: 40px;
@@ -283,8 +315,9 @@ body {
 
    가용 폭 980px = 슬라이드 1400 - 테두리 2 - ppt-content padding 24
                    - desc panel 380 - gap 12 - wireframe 테두리 2
-   가용 높이 671.5px = 787.5(16:9) - 테두리 2 - top bar 48 - footer 40
-                       - ppt-content padding 24 - wireframe 테두리 2
+   가용 높이 643.5px = 787.5(16:9) - 테두리 2 - top bar 48 - meta bar 28
+                       - footer 40 - ppt-content padding 24 - wireframe 테두리 2
+                       (box-sizing:border-box 이므로 각 테두리는 height 에 포함)
    2~3개: 320*0.9 = 288    -> 3*288 + 2*24(gap)   = 912   <= 980
    4개  : 320*0.68 = 217.6 -> 4*217.6 + 3*24(gap) = 942.4 <= 980
    5개 이상은 슬라이드를 나눈다. */


### PR DESCRIPTION
## 요약

화면 상세(`06.x`) 슬라이드에 상단 메타 바를 추가해 화면 위치(Location)를 표기한다.

Closes #17

실무 화면설계서 레퍼런스(은행 앱 `Bravo Korea CAR LOAN`)의 헤더 표를 참고했다. 레퍼런스는 `홈 > 상품 상세 > STEP.0,1,2,3,4,5,6,7,8(안면인식 완료) > 추가서류 제출` 처럼 진입점부터의 경로를 적어, IA 를 넘겨보지 않아도 화면 맥락이 잡히게 한다.

## 필드 선택 — Location 하나만

레퍼런스는 7개 필드를 담지만 하나만 채택했다.

| 필드 | 채택 | 이유 |
|---|---|---|
| Location | **O** | IA 없이도 맥락이 잡힌다. `04 IA` 에서 자동 유도 가능 |
| 요구사항 ID | X | 외부 요구사항 관리 도구의 키. 우리는 소스가 없어 채울 값이 없다. **레퍼런스조차 "요구사항 ID 명시" 플레이스홀더가 그대로 남아 있다** |
| 작업자 | X | Cover 슬라이드의 Author 와 중복 |
| Page No. | X | `NO. 06.2` 가 이미 그 역할 |
| 화면 Type | X | 이 스킬은 모바일 전용이라 값이 사실상 고정 |
| 화면 ID | 보류 | 이슈 #19 에서 체계를 정한 뒤 필드를 추가한다 |

빈 칸을 남기면 실무 문서의 겉모습만 흉내내게 되므로 넣지 않았다.

## 높이 예산 변화 — #13 과 얽힘

메타 바 28px 만큼 `ppt-content` 가 줄어 `ppt-wireframe` 가용 높이가 **671.5px → 643.5px** 가 된다. 목업은 zoom 0.9 에서 540px 이므로 그대로 들어가고, 이슈 #6 의 배지 gutter 도 영향받지 않는다(가로 방향 불변식이라 무관).

`scripts/multimock-probe.html` 의 기대값과 `template.html` 주석의 높이 식을 함께 갱신했다.

**계산을 한 번 틀렸다.** 처음 645.5px 로 적었는데 실측은 643.5px 였다. `box-sizing: border-box` 이므로 각 요소의 테두리가 `height` 에 이미 포함되는데 이를 이중으로 뺀 탓이었다. 실측값 기준으로 정정하고 주석에 그 이유를 남겼다.

## 검증

### 프로브 — 131 checks ALL PASS

프로브 슬라이드에도 메타 바를 넣어 실제 `06.x` 와 같은 조건으로 다시 측정했다.

| 측정 | 실측 | 기대 |
|---|---|---|
| `ppt-wireframe` content | 980.00 × **643.50** | 980.00 × 643.50 |
| `.mock` (1·2·3개) | 288.00 × 540.00 | 동일 |
| `.mock` (4개) | 217.59 × 408.00 | 217.60 × 408.00 |
| gutter 여유 | 1.80 / 1.36px | 동일 |
| 오버플로 | 없음 | 없음 |

### 예시 문서

브라우저 실측으로 확인했다.

- `06.1` → `Location 홈`, `06.2` → `Location 홈 > 기사 상세`
- `01`~`05` 슬라이드에는 메타 바 **없음** (화면이 아니므로 위치가 없다)
- 목업 540px 가 643.5px 안에 들어가고 오버플로 0, 배지 잘림 0

```
$ python3 generate_doksam.py && python3 -m unittest discover -s tests
생성 완료: examples/doksam_news_storyboard.html (슬라이드 7장)
Ran 24 tests in 0.004s
OK

$ ./tests/test_install.sh
pass=30 fail=0

$ git diff --exit-code examples/
(clean — 재생성 불변식 성립)

$ python3 scripts/check_output.py examples/doksam_news_storyboard.html
총 위반 0건
```

작업 중 템플릿만 바꾸고 예시를 재생성하지 않은 상태에서 테스트를 돌려 `test_committed_example_matches_generated_output` 이 실패한 적이 있다. 불변식 테스트가 의도대로 동작한 것이며, 재생성 후 통과를 확인하고 커밋했다.

## SKILL.md

- Class Quick Reference 에 `ppt-meta-bar` · `ppt-meta-label` · `ppt-meta-value` 3행 추가
- Workflow 에 Location 작성 규칙 추가 — `04 IA` 의 연결 관계에서 경로를 끌어오고, `01`~`05` 에는 넣지 않는다
- 마크업 예시에 메타 바 삽입
- 자체 점검에 7번 항목(화면 위치) 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)
