### PR TITLE
feat: 전역 화면 ID 체계 도입 (#19)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -126,6 +126,16 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* 메타 줄의 마지막 칸(화면 ID)을 우측으로 민다. */
+.ppt-meta-id {
+  margin-left: auto;
+  padding: 0 12px;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  color: #3f3f46;
+  letter-spacing: 0.02em;
+  flex: none;
+}
 
 /* Bottom Footer */
 .ppt-footer {
@@ -432,16 +442,17 @@ code {
         <table style="width:100%; border-collapse:collapse; text-align:left;">
           <tr style="background:#f4f4f4; border-bottom:2px solid #ccc;">
             <th style="padding:12px; border:1px solid #ddd;" width="90">NO.</th>
-            <th style="padding:12px; border:1px solid #ddd;" width="240">제목</th>
+            <th style="padding:12px; border:1px solid #ddd;" width="220">제목</th>
+            <th style="padding:12px; border:1px solid #ddd;" width="180">화면 ID</th>
             <th style="padding:12px; border:1px solid #ddd;">설명</th>
           </tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">01</td><td style="padding:12px; border:1px solid #ddd;">Cover</td><td style="padding:12px; border:1px solid #ddd;">문서 표지 — 서비스명, 버전, 작성일</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">02</td><td style="padding:12px; border:1px solid #ddd;">Document History</td><td style="padding:12px; border:1px solid #ddd;">개정 이력</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">03</td><td style="padding:12px; border:1px solid #ddd;">Index</td><td style="padding:12px; border:1px solid #ddd;">본 목차</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">04</td><td style="padding:12px; border:1px solid #ddd;">Information Architecture</td><td style="padding:12px; border:1px solid #ddd;">화면 트리 및 정보구조</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">05</td><td style="padding:12px; border:1px solid #ddd;">General Rule</td><td style="padding:12px; border:1px solid #ddd;">공통 규칙 — 레이아웃, 타이포, 컬러, 예외처리</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">06.1</td><td style="padding:12px; border:1px solid #ddd;">Main Home</td><td style="padding:12px; border:1px solid #ddd;">메인 홈 화면 상세</td></tr>
-          <tr><td style="padding:12px; border:1px solid #ddd;">06.2</td><td style="padding:12px; border:1px solid #ddd;">Article Detail</td><td style="padding:12px; border:1px solid #ddd;">기사 상세 화면 상세</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">01</td><td style="padding:12px; border:1px solid #ddd;">Cover</td><td style="padding:12px; border:1px solid #ddd;"></td><td style="padding:12px; border:1px solid #ddd;">문서 표지 — 서비스명, 버전, 작성일</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">02</td><td style="padding:12px; border:1px solid #ddd;">Document History</td><td style="padding:12px; border:1px solid #ddd;"></td><td style="padding:12px; border:1px solid #ddd;">개정 이력</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">03</td><td style="padding:12px; border:1px solid #ddd;">Index</td><td style="padding:12px; border:1px solid #ddd;"></td><td style="padding:12px; border:1px solid #ddd;">본 목차</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">04</td><td style="padding:12px; border:1px solid #ddd;">Information Architecture</td><td style="padding:12px; border:1px solid #ddd;"></td><td style="padding:12px; border:1px solid #ddd;">화면 트리 및 정보구조</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">05</td><td style="padding:12px; border:1px solid #ddd;">General Rule</td><td style="padding:12px; border:1px solid #ddd;"></td><td style="padding:12px; border:1px solid #ddd;">공통 규칙 — 레이아웃, 타이포, 컬러, 예외처리</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">06.1</td><td style="padding:12px; border:1px solid #ddd;">Main Home</td><td style="padding:12px; border:1px solid #ddd;">DSN-MAIN-001</td><td style="padding:12px; border:1px solid #ddd;">메인 홈 화면 상세</td></tr>
+          <tr><td style="padding:12px; border:1px solid #ddd;">06.2</td><td style="padding:12px; border:1px solid #ddd;">Article Detail</td><td style="padding:12px; border:1px solid #ddd;">DSN-ARTICLE-001</td><td style="padding:12px; border:1px solid #ddd;">기사 상세 화면 상세</td></tr>
         </table>
       </div>
     </div>
@@ -551,6 +562,7 @@ mindmap
     <div class="ppt-meta-bar">
       <div class="ppt-meta-label">Location</div>
       <div class="ppt-meta-value">홈</div>
+      <div class="ppt-meta-id">DSN-MAIN-001</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">
@@ -604,7 +616,7 @@ mindmap
               <span class="desc-num">①</span>
               <div>
                 <b>긴급 속보 배너</b><br>
-                가장 중요한 속보 기사를 상단에 강조 표시. 클릭 시 06.2 기사 상세로 이동.<br>
+                가장 중요한 속보 기사를 상단에 강조 표시. 클릭 시 기사 상세로 이동 (DSN-ARTICLE-001).<br>
                 <code>Banner (danger)</code>
               </div>
             </li>
@@ -642,6 +654,7 @@ mindmap
     <div class="ppt-meta-bar">
       <div class="ppt-meta-label">Location</div>
       <div class="ppt-meta-value">홈 > 기사 상세</div>
+      <div class="ppt-meta-id">DSN-ARTICLE-001</div>
     </div>
     <div class="ppt-content">
       <div class="ppt-wireframe">

--- a/generate_doksam.py
+++ b/generate_doksam.py
@@ -101,7 +101,7 @@ TH = 'style="padding:12px; border:1px solid #ddd;"'
 TD = 'style="padding:12px; border:1px solid #ddd;"'
 
 
-def _slide(no: str, title: str, body: str, location: str = "") -> str:
+def _slide(no: str, title: str, body: str, location: str = "", screen_id: str = "") -> str:
     """슬라이드 1장을 조립한다.
 
     body 는 ppt-content 내부 마크업. location 을 주면 상단 바 아래에
@@ -109,9 +109,11 @@ def _slide(no: str, title: str, body: str, location: str = "") -> str:
     """
     meta = ""
     if location:
+        sid = f'\n      <div class="ppt-meta-id">{screen_id}</div>' if screen_id else ""
         meta = (f'\n    <div class="ppt-meta-bar">'
                 f'\n      <div class="ppt-meta-label">Location</div>'
                 f'\n      <div class="ppt-meta-value">{location}</div>'
+                f'{sid}'
                 f'\n    </div>')
     return f"""
   <div class="ppt-slide">
@@ -166,24 +168,26 @@ def _history() -> str:
 
 def _index() -> str:
     rows = [
-        ("01", "Cover", "문서 표지 — 서비스명, 버전, 작성일"),
-        ("02", "Document History", "개정 이력"),
-        ("03", "Index", "본 목차"),
-        ("04", "Information Architecture", "화면 트리 및 정보구조"),
-        ("05", "General Rule", "공통 규칙 — 레이아웃, 타이포, 컬러, 예외처리"),
-        ("06.1", "Main Home", "메인 홈 화면 상세"),
-        ("06.2", "Article Detail", "기사 상세 화면 상세"),
+        ("01", "Cover", "", "문서 표지 — 서비스명, 버전, 작성일"),
+        ("02", "Document History", "", "개정 이력"),
+        ("03", "Index", "", "본 목차"),
+        ("04", "Information Architecture", "", "화면 트리 및 정보구조"),
+        ("05", "General Rule", "", "공통 규칙 — 레이아웃, 타이포, 컬러, 예외처리"),
+        ("06.1", "Main Home", "DSN-MAIN-001", "메인 홈 화면 상세"),
+        ("06.2", "Article Detail", "DSN-ARTICLE-001", "기사 상세 화면 상세"),
     ]
     tr = "\n".join(
-        f"          <tr><td {TD}>{no}</td><td {TD}>{title}</td><td {TD}>{desc}</td></tr>"
-        for no, title, desc in rows
+        f"          <tr><td {TD}>{no}</td><td {TD}>{title}</td>"
+        f"<td {TD}>{sid}</td><td {TD}>{desc}</td></tr>"
+        for no, title, sid, desc in rows
     )
     body = f"""      <div class="ppt-body-full">
         <h2 style="border-bottom:2px solid var(--accent); padding-bottom:10px; margin-bottom:20px; color:#333;">목차</h2>
         <table style="width:100%; border-collapse:collapse; text-align:left;">
           <tr style="background:#f4f4f4; border-bottom:2px solid #ccc;">
             <th {TH} width="90">NO.</th>
-            <th {TH} width="240">제목</th>
+            <th {TH} width="220">제목</th>
+            <th {TH} width="180">화면 ID</th>
             <th {TH}>설명</th>
           </tr>
 {tr}
@@ -318,7 +322,7 @@ def _main_home() -> str:
               <span class="desc-num">①</span>
               <div>
                 <b>긴급 속보 배너</b><br>
-                가장 중요한 속보 기사를 상단에 강조 표시. 클릭 시 06.2 기사 상세로 이동.<br>
+                가장 중요한 속보 기사를 상단에 강조 표시. 클릭 시 기사 상세로 이동 (DSN-ARTICLE-001).<br>
                 <code>Banner (danger)</code>
               </div>
             </li>
@@ -341,7 +345,7 @@ def _main_home() -> str:
           </ul>
         </div>
       </div>"""
-    return _slide("06.1", "Main Home", body, "홈")
+    return _slide("06.1", "Main Home", body, "홈", "DSN-MAIN-001")
 
 
 def _article_detail() -> str:
@@ -411,7 +415,7 @@ def _article_detail() -> str:
           </ul>
         </div>
       </div>"""
-    return _slide("06.2", "Article Detail", body, "홈 > 기사 상세")
+    return _slide("06.2", "Article Detail", body, "홈 > 기사 상세", "DSN-ARTICLE-001")
 
 
 def build_html(styles: str) -> str:

--- a/scripts/check_output.py
+++ b/scripts/check_output.py
@@ -75,6 +75,22 @@ def mock_counts(html):
     return out
 
 
+
+def screen_ids(html):
+    """ppt-meta-id 로 정의된 화면 ID 집합을 반환한다."""
+    return set(re.findall(r'class="ppt-meta-id">([^<]+)<', html))
+
+
+def referenced_ids(html):
+    """본문에서 언급된 화면 ID 후보를 반환한다.
+
+    형식은 <서비스약어>-<기능>-<3자리> 다. ppt-meta-id 안의 정의 자리는
+    제외하고, 설명 문장에서 참조된 것만 센다.
+    """
+    stripped = re.sub(r'class="ppt-meta-id">[^<]+<', 'class="ppt-meta-id"><', html)
+    return set(re.findall(r"\b([A-Z]{2,6}-[A-Z]{2,12}-\d{3})\b", stripped))
+
+
 def check(path, css):
     """한 산출물을 판정해 (위반 목록, 정보 목록) 을 반환한다."""
     html = Path(path).read_text(encoding="utf-8")
@@ -105,6 +121,13 @@ def check(path, css):
     if "{{" in html:
         violations.append(f"치환 안 된 플레이스홀더 {html.count('{{')}건")
 
+    defined = screen_ids(html)
+    dangling = sorted(referenced_ids(html) - defined)
+    if defined and dangling:
+        violations.append(
+            f"정의되지 않은 화면 ID 를 참조한다: {', '.join(dangling)}"
+        )
+
     nums = slide_numbers(html)
     info.append(f"슬라이드 {len(nums)}장: {' '.join(nums)}")
     info.append(f"크기 {len(html):,} bytes / 배지 {len(lefts)}개")
@@ -113,6 +136,8 @@ def check(path, css):
 
     order = screen_order(html)
     info.append("화면 순서: " + " / ".join(f"{n} {t.strip()}" for n, t in order))
+    if defined:
+        info.append(f"화면 ID {len(defined)}개: {' '.join(sorted(defined))}")
     mocks = mock_counts(html)
     multi = [f"{n}({c})" for n, c in mocks if c >= 2]
     info.append(f"목업 2개 이상 슬라이드 {len(multi)}개" + (f": {' '.join(multi)}" if multi else ""))

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -43,6 +43,17 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 **`06.x` 슬라이드에는 `ppt-meta-bar` 로 화면 위치를 적는다.** 진입점부터 그 화면까지의 경로를 `>` 로 잇는다 — 예: `홈 > 게시판 > 글 상세`. `04 IA` 의 연결 관계에서 그대로 끌어온다. 이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면이 앱 어디에 있는지 알 수 있다. `01`~`05` 슬라이드에는 넣지 않는다 — 화면이 아니므로 위치가 없다.
 
+**화면마다 화면 ID 를 부여하고 이동을 그 ID 로 가리킨다.** 슬라이드 번호(`06.2`)는 화면이 추가되면 밀리므로 참조가 어긋나고, 팝업처럼 슬라이드가 없는 대상은 가리킬 수도 없다.
+
+- 형식은 `<서비스약어>-<기능>-<3자리>` 다. 예: `DTC-BOARD-001`, `DTC-NOTICE-002`.
+  - 서비스약어는 프로젝트명에서 만든다 (덕삼테니스클럽 → `DTC`). 대문자 2~4자.
+  - 기능은 영문 대문자 단어 하나 (`MAIN` `BOARD` `NOTICE` `VOTE` `AWARD` `BOOKING` `MEMBER`).
+  - 같은 기능의 화면이 여럿이면 뒤 3자리로 구분한다 — 목록 `001`, 상세 `002`.
+- `ppt-meta-id` 에 표시한다. `03 Index` 표에도 ID 열을 둔다.
+- **이동 서술은 이름과 ID 를 함께 적는다** — `글 상세로 이동 (DTC-BOARD-002)`. ID 만 쓰면 읽기 어렵다.
+- 팝업·바텀시트에도 ID 를 준다. 슬라이드가 없어도 참조 대상이므로 필요하다.
+- **본문에서 참조한 ID 는 모두 이 문서 안에 정의되어 있어야 한다.** 정의 없는 ID 를 가리키면 끊어진 참조다.
+
 화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 번호(1, 2, 3...)와 설명 리스트의 `desc-num` 기호(①, ②, ③...)를 **1:1 로 대응**시킨다. 설명 항목 수와 배지 수가 같아야 한다 — `mock-footer` 처럼 `mock-body` 밖의 요소를 설명하는 항목도 배지를 빠뜨리지 않는다(아래 마크업 참고).
 
 `pointer-badge` 는 `left:2px` 로 둔다. `mock-body` 의 좌측 28px 여백이 배지 자리다. **`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 28px 이상으로 유지한다** — 그러지 않으면 배지가 본문 텍스트를 가린다.
@@ -88,6 +99,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `ppt-meta-bar` | 상단 바 아래 메타 줄. **화면 상세(`06.x`)에만** 둔다 |
 | `ppt-meta-label` | 메타 줄의 회색 라벨 칸 (`Location`) |
 | `ppt-meta-value` | 메타 줄의 값 칸. 넘치면 말줄임 |
+| `ppt-meta-id` | 메타 줄 우측 화면 ID 칸 |
 | `ppt-content` | 중간 영역 컨테이너 |
 | `ppt-body-full` | 좌우 분할하지 않는 통짜 콘텐츠 (01~05) |
 | `ppt-wireframe` | 좌측 와이어프레임 패널 (06.x). **`mock` 을 1개 이상(최대 4개) 배치할 수 있다** — 개수에 따라 축소율과 간격을 템플릿이 자동 조절한다 |
@@ -111,7 +123,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 ## 저장 전 자체 점검
 
-파일을 저장하기 전에 완성된 마크업을 훑으며 아래 일곱 가지를 센다. 어긋나는 항목이 있으면 저장 전에 고친다. 템플릿의 CSS 를 그대로 옮기지 않고 다시 썼더라도 이 점검은 그대로 수행한다.
+파일을 저장하기 전에 완성된 마크업을 훑으며 아래 여덟 가지를 센다. 어긋나는 항목이 있으면 저장 전에 고친다. 템플릿의 CSS 를 그대로 옮기지 않고 다시 썼더라도 이 점검은 그대로 수행한다.
 
 1. **클래스** — 산출물에 등장하는 `class` 값을 전부 모아 Class Quick Reference 표와 대조한다. 표에 없는 이름이 하나라도 있으면 그 `class` 를 지우고 같은 효과를 인라인 `style` 로 옮긴다. 표에 없는 클래스는 CSS 정의가 없어 아무 스타일도 적용되지 않는다.
 2. **이모지** — 이모지 개수가 0 인가. 하나라도 있으면 Phosphor 인라인 SVG 아이콘으로 바꾸거나 지운다. `‹` `⋮` 같은 타이포그래피 문자는 이모지가 아니므로 그대로 둔다.
@@ -120,6 +132,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 5. **화면 순서** — `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `06.x` 슬라이드 순서 세 곳이 같은가. 그리고 그 순서가 사용자가 기능을 나열한 순서와 같은가(진입 화면은 `06.1`). 다르면 사용자 나열 순서를 기준으로 세 곳을 함께 맞춘다.
 6. **목업 개수** — `06.x` 마다 목업 트리거 표(위 `## 목업 여러 개 배치`)를 대조한다. 트리거에 해당하는데 `mock` 이 1개면 2개로 늘리고 `mock-caption` 을 붙인다. 해당하지 않는데 2개면 1개로 줄인다.
 7. **화면 위치** — `06.x` 마다 `ppt-meta-bar` 가 있고 값이 `04 IA` 의 경로와 맞는가. `01`~`05` 에는 없어야 한다.
+8. **화면 ID** — `06.x` 마다 `ppt-meta-id` 가 있는가. 본문에서 참조한 ID 가 모두 이 문서에 정의되어 있는가. 정의 없는 ID 를 가리키면 그 화면을 추가하거나 참조를 고친다.
 
 # Icons
 
@@ -151,6 +164,7 @@ description: Use when the user asks for a mobile web or app screen design docume
   <div class="ppt-meta-bar">
     <div class="ppt-meta-label">Location</div>
     <div class="ppt-meta-value">홈</div>
+    <div class="ppt-meta-id">DTC-MAIN-001</div>
   </div>
 
   <div class="ppt-content">

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -125,6 +125,16 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* 메타 줄의 마지막 칸(화면 ID)을 우측으로 민다. */
+.ppt-meta-id {
+  margin-left: auto;
+  padding: 0 12px;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  color: #3f3f46;
+  letter-spacing: 0.02em;
+  flex: none;
+}
 
 /* Bottom Footer */
 .ppt-footer {


### PR DESCRIPTION
## 요약

화면마다 전역 ID 를 부여하고 화면 간 이동을 그 ID 로 가리킨다.

Closes #19

슬라이드 번호(`06.2`)로 가리키면 화면이 추가될 때 번호가 밀려 참조가 어긋나고, 팝업처럼 슬라이드가 없는 대상은 가리킬 수도 없다. 실무 화면설계서 레퍼런스는 전역 화면 ID(`APnfd0306013000`)로 이 문제를 해결하며, 실제로 레퍼런스 두 페이지가 그 ID 로 연결된다.

## 형식 — `<서비스약어>-<기능>-<3자리>`

이슈의 A/B/C 후보 중 **A** 를 채택했다. 근거는 실측이다.

1라운드에서 `agy` 가 **스킬 없이** 만들 때 자발적으로 이 형태를 골랐다.

```
DTC-MAIN-001  DTC-NOTI-001  DTC-NOTI-002
DTC-BOARD-001 DTC-BOARD-002 DTC-AWARD-001
DTC-MEMB-001  DTC-RESRV-001
```

목록과 상세를 뒤 3자리로 구분하는 관례까지 스스로 적용했다. 에이전트가 자연스럽게 선호하는 형태이므로 지시 비용이 낮다.

- **B (슬러그)** — 한글 화면명을 영문으로 옮기는 판단이 매번 개입해 재현성이 낮다.
- **C (혼용)** — 슬라이드 번호와 ID 두 체계가 섞여 일관성이 떨어진다.

## 변경

| 파일 | 내용 |
|---|---|
| `template.html` | `ppt-meta-id` 클래스. 메타 줄 우측에 모노스페이스로 표시 |
| `SKILL.md` | 형식 규칙, 이동 서술 시 이름과 ID 병기, 팝업에도 ID 부여, 참조한 ID 는 모두 정의되어야 함 |
| `SKILL.md` | 자체 점검 8번 항목(화면 ID) 추가 |
| `generate_doksam.py` | `_slide()` 에 `screen_id` 인자, `03 Index` 표에 화면 ID 열 |
| 예시 | 이동 서술을 `클릭 시 06.2 기사 상세로 이동` → `클릭 시 기사 상세로 이동 (DSN-ARTICLE-001)` |

이동 서술에 **이름과 ID 를 함께** 적게 했다. ID 만 쓰면 읽는 사람이 매번 찾아봐야 한다.

## 끊어진 참조 검사

`scripts/check_output.py` 에 `screen_ids()` 와 `referenced_ids()` 를 추가해, 본문에서 참조한 ID 가 문서에 정의되어 있지 않으면 **위반으로 판정**한다.

화면 순서·목업 개수와 달리 이것은 요청 맥락 없이도 옳고 그름이 정해지므로 보고가 아니라 판정 대상이다.

양방향 검증:

```
$ python3 scripts/check_output.py tmp/dangling-test.html   # DSN-SETTINGS-001 주입
  X 정의되지 않은 화면 ID 를 참조한다: DSN-SETTINGS-001
  => 위반 1건
exit=1

$ python3 scripts/check_output.py examples/doksam_news_storyboard.html
  · 화면 ID 2개: DSN-ARTICLE-001 DSN-MAIN-001
  => 계약 위반 없음
exit=0
```

## 검증

브라우저 실측으로 메타 줄이 `Location 홈` + `DSN-MAIN-001` 2칸으로 렌더되는 것을 확인했다. 높이 예산은 변하지 않는다 — `ppt-wireframe` 645.5px, 목업 540px, 오버플로 없음. 이슈 #17 에서 갱신한 프로브 기대값에 영향이 없다.

```
$ python3 generate_doksam.py && python3 -m unittest discover -s tests
생성 완료: examples/doksam_news_storyboard.html (슬라이드 7장)
Ran 24 tests in 0.004s
OK

$ ./tests/test_install.sh
pass=30 fail=0

$ git diff --exit-code examples/
(clean — 재생성 불변식 성립)
```

## 남은 것

`06.x` 슬라이드에만 ID 를 부여했다. 팝업·바텀시트 ID 는 이슈 #20(부분 목업)에서 그 표현 방법과 함께 정한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
