### PR TITLE
feat: pointer-badge 를 2단 계층 번호로 (#18)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -248,11 +248,16 @@ body {
 }
 
 /* Pointer Badges on Wireframe */
+/* 배지는 가변 폭이다. "1" 같은 한 글자는 min-width 로 24px 정사각형을
+   유지하고, 2단 번호("2-1")는 내용만큼 늘어난다. 늘어난 폭은 아래
+   목업 2개 이상일 때의 넓은 gutter 안에 들어간다. */
 .pointer-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
+  min-width: 24px;
+  width: auto;
+  padding: 0 4px;
   height: 24px;
   background: var(--accent);
   color: var(--accent-ink);
@@ -300,6 +305,11 @@ body {
    절반을 잘라낸다. 배지를 left:2px 로 이 여백 안에 두면 온전히 보이고
    콘텐츠(28px 부터 시작)와 겹치지도 않는다. 배지 폭 24px + 여유 4px. */
 .mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
+/* 목업이 2개 이상이면 배지가 2단 번호("2-1")가 되어 폭이 늘어난다.
+   gutter 를 34px 로 넓혀 배지가 콘텐츠를 가리지 않게 한다. 이 규칙은
+   목업 복수 배치와 같은 :has(.mock ~ .mock) 로 게이트되므로 단일 목업
+   슬라이드의 28px gutter 는 그대로다(이슈 #6 무회귀). */
+.ppt-wireframe:has(.mock ~ .mock) .mock-body { padding-left: 34px; }
 .mock-footer {
   border-top: 1px solid #e2e8f0;
   display: flex;

--- a/scripts/build_multimock_probe.py
+++ b/scripts/build_multimock_probe.py
@@ -74,9 +74,9 @@ def slide(no, title, mocks):
 
 # 1개 슬라이드는 회귀 기준선 — 캡션 없이 기존 예시와 동일한 구조.
 S1 = slide("06.1", "1 mock (regression baseline, no caption)", [mock(None, [(1, 20), (2, 100)])])
-S2 = slide("06.2", "2 mocks (zoom 0.9)", [mock("기본 상태", [(1, 20), (2, 100)]), mock("선택됨", [(3, 20)])])
-S3 = slide("06.3", "3 mocks (zoom 0.9)", [mock("입력", [(1, 20)]), mock("확인", [(2, 20)]), mock("완료", [(3, 20)])])
-S4 = slide("06.4", "4 mocks (zoom 0.68)", [mock(f"단계 {i}", [(i, 20)]) for i in range(1, 5)])
+S2 = slide("06.2", "2 mocks (zoom 0.9, 2단 번호)", [mock("기본 상태", [("1-1", 20), ("1-2", 100)]), mock("선택됨", [("2-1", 20)])])
+S3 = slide("06.3", "3 mocks (zoom 0.9, 2단 번호)", [mock("입력", [("1-1", 20)]), mock("확인", [("2-1", 20)]), mock("완료", [("3-1", 20)])])
+S4 = slide("06.4", "4 mocks (zoom 0.68, 2단 번호)", [mock(f"단계 {i}", [(f"{i}-1", 20)]) for i in range(1, 5)])
 
 SCRIPT = r"""
 <script>
@@ -118,8 +118,9 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
       chk(tag+'badge['+i+','+j+'] not clipped by mock-screen (left)', br.left>=msr.left-0.5, true);
       chk(tag+'badge['+i+','+j+'] right of mock-body box left', br.left>=bodyr.left-0.5, true);
       chk(tag+'badge['+i+','+j+'] right edge <= content left (gutter clear)', br.right<=cr.left+0.02, true);
-      chk(tag+'badge['+i+','+j+'] gutter clearance px', cr.left-br.right, 1.8*z/0.9, 0.6);
-      chk(tag+'badge['+i+','+j+'] width', br.width, 24*z, 0.5);
+      chk(tag+'badge['+i+','+j+'] gutter clearance >= 0', cr.left-br.right >= -0.02, true);
+      // 배지는 가변 폭이다. 한 글자는 24px, 2단 번호는 내용만큼 넓어진다.
+      chk(tag+'badge['+i+','+j+'] width >= 24 (min-width)', br.width >= 24*z-0.5, true);
     });
   });
 });

--- a/scripts/multimock-probe.html
+++ b/scripts/multimock-probe.html
@@ -109,6 +109,16 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* 메타 줄의 마지막 칸(화면 ID)을 우측으로 민다. */
+.ppt-meta-id {
+  margin-left: auto;
+  padding: 0 12px;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  color: #3f3f46;
+  letter-spacing: 0.02em;
+  flex: none;
+}
 
 /* Bottom Footer */
 .ppt-footer {
@@ -221,11 +231,16 @@ body {
 }
 
 /* Pointer Badges on Wireframe */
+/* 배지는 가변 폭이다. "1" 같은 한 글자는 min-width 로 24px 정사각형을
+   유지하고, 2단 번호("2-1")는 내용만큼 늘어난다. 늘어난 폭은 아래
+   목업 2개 이상일 때의 넓은 gutter 안에 들어간다. */
 .pointer-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
+  min-width: 24px;
+  width: auto;
+  padding: 0 4px;
   height: 24px;
   background: var(--accent);
   color: var(--accent-ink);
@@ -273,6 +288,11 @@ body {
    절반을 잘라낸다. 배지를 left:2px 로 이 여백 안에 두면 온전히 보이고
    콘텐츠(28px 부터 시작)와 겹치지도 않는다. 배지 폭 24px + 여유 4px. */
 .mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
+/* 목업이 2개 이상이면 배지가 2단 번호("2-1")가 되어 폭이 늘어난다.
+   gutter 를 34px 로 넓혀 배지가 콘텐츠를 가리지 않게 한다. 이 규칙은
+   목업 복수 배치와 같은 :has(.mock ~ .mock) 로 게이트되므로 단일 목업
+   슬라이드의 28px gutter 는 그대로다(이슈 #6 무회귀). */
+.ppt-wireframe:has(.mock ~ .mock) .mock-body { padding-left: 34px; }
 .mock-footer {
   border-top: 1px solid #e2e8f0;
   display: flex;
@@ -299,8 +319,9 @@ body {
 
    가용 폭 980px = 슬라이드 1400 - 테두리 2 - ppt-content padding 24
                    - desc panel 380 - gap 12 - wireframe 테두리 2
-   가용 높이 671.5px = 787.5(16:9) - 테두리 2 - top bar 48 - footer 40
-                       - ppt-content padding 24 - wireframe 테두리 2
+   가용 높이 643.5px = 787.5(16:9) - 테두리 2 - top bar 48 - meta bar 28
+                       - footer 40 - ppt-content padding 24 - wireframe 테두리 2
+                       (box-sizing:border-box 이므로 각 테두리는 height 에 포함)
    2~3개: 320*0.9 = 288    -> 3*288 + 2*24(gap)   = 912   <= 980
    4개  : 320*0.68 = 217.6 -> 4*217.6 + 3*24(gap) = 942.4 <= 980
    5개 이상은 슬라이드를 나눈다. */
@@ -393,7 +414,7 @@ code {
   <div class="ppt-slide" data-mockcount="2">
     <div class="ppt-top-bar">
       <div class="ppt-top-no">NO. 06.2</div>
-      <div class="ppt-top-title">2 mocks (zoom 0.9)</div>
+      <div class="ppt-top-title">2 mocks (zoom 0.9, 2단 번호)</div>
       <div class="ppt-top-proj">PROBE</div>
     </div>
     <div class="ppt-meta-bar">
@@ -407,8 +428,8 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
-              <span class="pointer-badge" style="position:absolute; top:100px; left:2px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1-1</span>
+              <span class="pointer-badge" style="position:absolute; top:100px; left:2px; z-index:10;">1-2</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -424,7 +445,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -449,7 +470,7 @@ code {
   <div class="ppt-slide" data-mockcount="3">
     <div class="ppt-top-bar">
       <div class="ppt-top-no">NO. 06.3</div>
-      <div class="ppt-top-title">3 mocks (zoom 0.9)</div>
+      <div class="ppt-top-title">3 mocks (zoom 0.9, 2단 번호)</div>
       <div class="ppt-top-proj">PROBE</div>
     </div>
     <div class="ppt-meta-bar">
@@ -463,7 +484,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -479,7 +500,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -495,7 +516,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -520,7 +541,7 @@ code {
   <div class="ppt-slide" data-mockcount="4">
     <div class="ppt-top-bar">
       <div class="ppt-top-no">NO. 06.4</div>
-      <div class="ppt-top-title">4 mocks (zoom 0.68)</div>
+      <div class="ppt-top-title">4 mocks (zoom 0.68, 2단 번호)</div>
       <div class="ppt-top-proj">PROBE</div>
     </div>
     <div class="ppt-meta-bar">
@@ -534,7 +555,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -550,7 +571,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -566,7 +587,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -582,7 +603,7 @@ code {
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
             <div class="mock-body" style="position:relative;">
-              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">4</span>
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">4-1</span>
               <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
               <div style="background:#eee; height:60px;">content B</div>
             </div>
@@ -644,8 +665,9 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
       chk(tag+'badge['+i+','+j+'] not clipped by mock-screen (left)', br.left>=msr.left-0.5, true);
       chk(tag+'badge['+i+','+j+'] right of mock-body box left', br.left>=bodyr.left-0.5, true);
       chk(tag+'badge['+i+','+j+'] right edge <= content left (gutter clear)', br.right<=cr.left+0.02, true);
-      chk(tag+'badge['+i+','+j+'] gutter clearance px', cr.left-br.right, 1.8*z/0.9, 0.6);
-      chk(tag+'badge['+i+','+j+'] width', br.width, 24*z, 0.5);
+      chk(tag+'badge['+i+','+j+'] gutter clearance >= 0', cr.left-br.right >= -0.02, true);
+      // 배지는 가변 폭이다. 한 글자는 24px, 2단 번호는 내용만큼 넓어진다.
+      chk(tag+'badge['+i+','+j+'] width >= 24 (min-width)', br.width >= 24*z-0.5, true);
     });
   });
 });

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -54,9 +54,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 - 팝업·바텀시트에도 ID 를 준다. 슬라이드가 없어도 참조 대상이므로 필요하다.
 - **본문에서 참조한 ID 는 모두 이 문서 안에 정의되어 있어야 한다.** 정의 없는 ID 를 가리키면 끊어진 참조다.
 
-화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 번호(1, 2, 3...)와 설명 리스트의 `desc-num` 기호(①, ②, ③...)를 **1:1 로 대응**시킨다. 설명 항목 수와 배지 수가 같아야 한다 — `mock-footer` 처럼 `mock-body` 밖의 요소를 설명하는 항목도 배지를 빠뜨리지 않는다(아래 마크업 참고).
+화면 상세 슬라이드는 좌측 `ppt-wireframe` 에 모바일 목업을, 우측 `ppt-desc-panel` 에 설명을 넣는다. 목업 위의 `pointer-badge` 와 설명 리스트의 `desc-num` 을 **1:1 로 대응**시킨다. 목업이 1개면 `1, 2, 3` ↔ `①②③`, 2개 이상이면 2단 번호(`1-1`, `2-1`)를 양쪽에 같이 쓴다. 설명 항목 수와 배지 수가 같아야 한다 — `mock-footer` 처럼 `mock-body` 밖의 요소를 설명하는 항목도 배지를 빠뜨리지 않는다(아래 마크업 참고).
 
-`pointer-badge` 는 `left:2px` 로 둔다. `mock-body` 의 좌측 28px 여백이 배지 자리다. **`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 28px 이상으로 유지한다** — 그러지 않으면 배지가 본문 텍스트를 가린다.
+`pointer-badge` 는 `left:2px` 로 둔다. `mock-body` 좌측 여백이 배지 자리이며 폭은 템플릿이 정한다 — 목업 1개면 28px, 2개 이상이면 2단 번호가 넓어지므로 34px 다. **`mock-body` 에 인라인 `padding` 을 줄 때는 `padding-left` 를 이 값 이상으로 유지한다**(목업 1개 28px, 2개 이상 34px) — 그러지 않으면 배지가 본문 텍스트를 가린다.
 
 ## 목업 여러 개 배치
 
@@ -73,7 +73,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 - **개수는 최대 4개.** 템플릿이 개수를 감지해 축소율을 조절한다(1개: 그대로, 2~3개: 90%, 4개: 68%). 5개 이상은 잘리므로 슬라이드를 나눈다.
 - **각 목업에 `mock-caption` 으로 라벨을 붙인다** — `mock` 의 마지막 자식으로 두면 프레임 바로 아래에 표시된다. 무엇의 변형인지 알 수 없으면 비교 슬라이드의 의미가 없다.
-- **`pointer-badge` 번호는 슬라이드 단위 연속 번호다.** 목업별로 1 부터 다시 시작하지 않는다 — 우측 `desc-list` 는 슬라이드에 하나뿐이고 `desc-num` 과 1:1 로 대응해야 하므로, 번호가 중복되면 어느 목업의 항목인지 가리킬 수 없다. 첫 목업의 배지를 위에서 아래로 매기고, 다음 목업에서 이어서 매긴다(첫 목업 1·2 → 두 번째 목업 3·4). 설명 항목에는 어느 목업인지 라벨을 함께 적는다.
+- **`pointer-badge` 번호는 2단이다** — `<목업번호>-<요소번호>`. 첫 목업의 요소는 `1-1` `1-2`, 두 번째 목업은 `2-1` `2-2` 로 매긴다. 목업이 몇 번째인지가 번호에서 바로 읽히므로 "어느 목업의 항목인지" 를 따로 적을 필요가 없다.
+- **`desc-num` 도 같은 2단 표기를 쓴다.** 원문자(①②③)는 2단을 표현할 수 없으므로 목업이 2개 이상인 슬라이드에서는 `1-1` 처럼 평문으로 적는다. 목업이 1개면 지금처럼 원문자를 쓴다.
+- 설명 리스트는 목업 순서대로 묶어 적는다 — `1-1` `1-2` 를 먼저, 그다음 `2-1` `2-2`.
 - 목업 간 간격·정렬·축소는 템플릿이 처리한다. `ppt-wireframe` 이나 `mock` 에 인라인 `width`·`transform`·`zoom`·`margin` 을 주지 않는다.
 
 # Color
@@ -108,7 +110,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `ppt-desc-body` | 설명 패널 본문 |
 | `desc-list` | 설명 리스트 (`ul`) |
 | `desc-num` | 설명 항목 번호 (①②③) |
-| `pointer-badge` | 목업 위 accent 컬러 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 의 좌측 28px 여백이 배지 자리다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
+| `pointer-badge` | 목업 위 accent 컬러 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 좌측 여백(1개 28px · 2개 이상 34px)이 배지 자리다. 폭은 내용에 맞춰 늘어난다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
 | `mock` | 모바일 목업 외곽 프레임. `ppt-wireframe` 안에 여러 개 둘 수 있다 |
 | `mock-caption` | 목업 라벨 (`기본 상태` / `선택됨`). `mock` 의 마지막 자식으로 두면 프레임 아래에 표시된다. 목업이 2개 이상이면 필수 || `mock-screen` | 목업 화면 |
 | `mock-status` | 목업 상태바 |

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -247,11 +247,16 @@ body {
 }
 
 /* Pointer Badges on Wireframe */
+/* 배지는 가변 폭이다. "1" 같은 한 글자는 min-width 로 24px 정사각형을
+   유지하고, 2단 번호("2-1")는 내용만큼 늘어난다. 늘어난 폭은 아래
+   목업 2개 이상일 때의 넓은 gutter 안에 들어간다. */
 .pointer-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
+  min-width: 24px;
+  width: auto;
+  padding: 0 4px;
   height: 24px;
   background: var(--accent);
   color: var(--accent-ink);
@@ -299,6 +304,11 @@ body {
    절반을 잘라낸다. 배지를 left:2px 로 이 여백 안에 두면 온전히 보이고
    콘텐츠(28px 부터 시작)와 겹치지도 않는다. 배지 폭 24px + 여유 4px. */
 .mock-body { padding: 16px 16px 16px 28px; flex: 1; background: #fff; overflow-y: auto; }
+/* 목업이 2개 이상이면 배지가 2단 번호("2-1")가 되어 폭이 늘어난다.
+   gutter 를 34px 로 넓혀 배지가 콘텐츠를 가리지 않게 한다. 이 규칙은
+   목업 복수 배치와 같은 :has(.mock ~ .mock) 로 게이트되므로 단일 목업
+   슬라이드의 28px gutter 는 그대로다(이슈 #6 무회귀). */
+.ppt-wireframe:has(.mock ~ .mock) .mock-body { padding-left: 34px; }
 .mock-footer {
   border-top: 1px solid #e2e8f0;
   display: flex;


### PR DESCRIPTION
## 요약

`pointer-badge` 를 `<목업번호>-<요소번호>` 2단 계층으로 바꾼다.

Closes #18

실무 화면설계서 레퍼런스는 `1` → `1-1`, `2` → `2-1`, `2-2` 로 매긴다. 목업이 몇 번째인지가 번호에서 바로 읽히므로 "어느 목업의 항목인지" 를 설명에 따로 적을 필요가 없다. 기존 슬라이드 단위 연속 번호(이슈 #13)는 그 우회를 문서 규칙으로 요구하고 있었다.

## 이슈 #6 불변식 재계산

`2-1` 은 24px 정사각형에 들어가지 않으므로 배지를 가변 폭으로 바꿨다.

```css
.pointer-badge { min-width: 24px; width: auto; padding: 0 4px; height: 24px; }
```

한 글자는 `min-width` 로 정사각형을 유지하고 2단 번호만 늘어난다.

gutter 는 **조건부로** 넓힌다.

```css
.ppt-wireframe:has(.mock ~ .mock) .mock-body { padding-left: 34px; }
```

2단 번호는 목업이 2개 이상일 때만 쓰이므로, 넓은 gutter 도 이슈 #13 과 **같은 `:has(.mock ~ .mock)` 로 게이트**했다. 단일 목업 슬라이드의 28px gutter 는 그대로여서 기존 문서에 회귀가 없다.

## 실측으로 값을 정했다

처음 40px 로 잡았으나 브라우저 실측에서 여유가 11~13px 남아 과했다. **34px 로 줄여 목업 콘텐츠 폭을 6px 회수**했고, 그래도 최소 여유 4.60px 를 확보한다.

| 케이스 | 배지 폭 | gutter | 여유 |
|---|---|---|---|
| 단일 `1` (zoom 1) | 21.60 | 28 | 4.60 |
| 2목업 `1-1` (zoom 0.9) | 24.97 | 34 | 7.23 |
| 2목업 `2-1` (zoom 0.9) | 26.73 | 34 | 5.47 |
| 3목업 `3-1` (zoom 0.9) | 27.09 | 34 | 5.12 |

zoom 배율에서도 성립하는 이유는 gutter·배지·`left` 가 모두 같은 zoom 서브트리 안이라 배율이 함께 곱해지기 때문이다(이슈 #13 과 동일한 근거).

## 검증

**프로브 131 checks ALL PASS.** 프로브가 2단 번호를 쓰도록 갱신했고, 배지 폭이 가변이 되었으므로 고정값 기대치를 다음으로 바꿨다.

- `width` → `min-width 이상` 인지
- `gutter clearance` → `>= 0` 인지 (고정 1.8px 기대 대신)

음수 여유 0건, 최소 여유 4.60px.

**`check_output.py` 의 2단 배지 인식 확인.** 실제 산출물(`output/round3/claude`)의 `06.2` 배지를 `1-1`~`2-3` 으로 치환해 돌렸고, 배지 31개를 정상 인식하며 위반 0 으로 통과했다. `badge_lefts()` 와 `badge_desc_mismatch()` 는 `left` 값과 개수만 보므로 라벨 형식에 영향받지 않는다.

**단일 목업 무회귀.** 예시 문서는 `06.x` 두 슬라이드 모두 목업이 1개라 `:has` 규칙이 매치되지 않는다(측정 결과 매치 0건). 렌더가 바뀌지 않는다.

```
$ python3 -m unittest discover -s tests
Ran 24 tests in 0.004s
OK

$ ./tests/test_install.sh
pass=30 fail=0

$ git diff --exit-code examples/     # 스테이징 후 재생성
(clean — 재생성 불변식 성립)

$ python3 scripts/check_output.py examples/doksam_news_storyboard.html
총 위반 0건
```

## SKILL.md

- 2단 번호 규칙과 `desc-num` 표기 — 목업 1개는 원문자(①②③), 2개 이상은 평문(`1-1`)
- gutter 폭이 조건부(28 / 34)임을 인라인 `padding` 주의사항과 함께 명시
- Class Quick Reference 의 `pointer-badge` 행 갱신

## 남은 것

이슈 #20(팝업 부분 목업)이 이 PR 의 `3` → `3-1` 부모-자식 관계에 의존한다. 이제 그 표현이 가능해졌다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
