### PR TITLE
feat: 팝업·바텀시트를 부분 목업으로 표현 (#20)

### DIFF
--- a/examples/doksam_news_storyboard.html
+++ b/examples/doksam_news_storyboard.html
@@ -364,6 +364,17 @@ body {
   color: #555;
 }
 
+/* 부분 목업 — 팝업·바텀시트·토스트처럼 화면 일부만 덮는 요소.
+   .mock 과 함께 쓴다: <div class="mock mock-partial">
+   전체 화면 목업으로 그리면 별개 화면처럼 보이므로, 높이를 줄여
+   "화면 일부를 덮는다" 는 사실 자체를 그림으로 전달한다.
+   위쪽 배경 힌트(회색으로 뭉갠 영역)는 인라인 style 로 채운다.
+   .mock 의 형제이므로 :has(.mock ~ .mock) 규칙에 그대로 걸려
+   zoom 과 gutter 가 전체 목업과 동일하게 적용된다. */
+.mock-partial {
+  height: 320px;
+}
+
 /* Code tags */
 code {
   background: #f1f5f9;

--- a/scripts/build_multimock_probe.py
+++ b/scripts/build_multimock_probe.py
@@ -19,14 +19,15 @@ css = re.search(
 ).group(1)
 
 
-def mock(caption, badges):
+def mock(caption, badges, partial=False):
     b = "\n".join(
         f'              <span class="pointer-badge" style="position:absolute; '
         f'top:{t}px; left:2px; z-index:10;">{n}</span>'
         for n, t in badges
     )
     cap = f'\n          <div class="mock-caption">{caption}</div>' if caption else ""
-    return f"""        <div class="mock">
+    cls = "mock mock-partial" if partial else "mock"
+    return f"""        <div class="{cls}">
           <div class="mock-screen">
             <div class="mock-status"></div>
             <div class="mock-header"><span>HEADER</span></div>
@@ -77,6 +78,7 @@ S1 = slide("06.1", "1 mock (regression baseline, no caption)", [mock(None, [(1, 
 S2 = slide("06.2", "2 mocks (zoom 0.9, 2단 번호)", [mock("기본 상태", [("1-1", 20), ("1-2", 100)]), mock("선택됨", [("2-1", 20)])])
 S3 = slide("06.3", "3 mocks (zoom 0.9, 2단 번호)", [mock("입력", [("1-1", 20)]), mock("확인", [("2-1", 20)]), mock("완료", [("3-1", 20)])])
 S4 = slide("06.4", "4 mocks (zoom 0.68, 2단 번호)", [mock(f"단계 {i}", [(f"{i}-1", 20)]) for i in range(1, 5)])
+S5 = slide("06.5", "2 mocks + 부분 목업 (팝업)", [mock("기본", [("1-1", 20)]), mock("바텀시트 열림", [("2-1", 20)], partial=True)])
 
 SCRIPT = r"""
 <script>
@@ -94,7 +96,9 @@ function chk(name, actual, expected, tol){
              (typeof expected==='number'?expected.toFixed(2):String(expected)), ok?'PASS':'FAIL']);
 }
 document.querySelectorAll('.ppt-slide').forEach(function(slide){
-  var n = +slide.dataset.mockcount, tag='['+n+'-mock] ';
+  var n = +slide.dataset.mockcount;
+  var no = slide.querySelector('.ppt-top-no').textContent.replace('NO. ','');
+  var tag='['+no+' '+n+'-mock] ';
   var wf = slide.querySelector('.ppt-wireframe'), wi = inner(wf);
   chk(tag+'ppt-wireframe content width', wi.right-wi.left, 980, 1.5);
   chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 643.5, 1.5);
@@ -105,7 +109,8 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
   mocks.forEach(function(m,i){
     var mr=r(m);
     chk(tag+'mock['+i+'] visual width', mr.width, 320*z, 1.0);
-    chk(tag+'mock['+i+'] visual height', mr.height, 600*z, 1.5);
+    var baseH = m.classList.contains('mock-partial') ? 320 : 600;
+    chk(tag+'mock['+i+'] visual height', mr.height, baseH*z, 1.5);
     chk(tag+'mock['+i+'] inside wireframe (left)', mr.left>=wi.left-0.5, true);
     chk(tag+'mock['+i+'] inside wireframe (right)', mr.right<=wi.right+0.5, true);
     if(i>0) chk(tag+'gap mock['+(i-1)+']->mock['+i+']', mr.left-r(mocks[i-1]).right, 24, 1.0);
@@ -147,7 +152,7 @@ DOC = f"""<!DOCTYPE html>
 <body>
 <div id="probe-out" style="max-width:1400px; margin:0 auto 40px; background:#fff; padding:20px;">measuring...</div>
 <div class="docwrap">
-{S1}{S2}{S3}{S4}</div>
+{S1}{S2}{S3}{S4}{S5}</div>
 {SCRIPT}
 </body>
 </html>

--- a/scripts/multimock-probe.html
+++ b/scripts/multimock-probe.html
@@ -347,6 +347,17 @@ body {
   color: #555;
 }
 
+/* 부분 목업 — 팝업·바텀시트·토스트처럼 화면 일부만 덮는 요소.
+   .mock 과 함께 쓴다: <div class="mock mock-partial">
+   전체 화면 목업으로 그리면 별개 화면처럼 보이므로, 높이를 줄여
+   "화면 일부를 덮는다" 는 사실 자체를 그림으로 전달한다.
+   위쪽 배경 힌트(회색으로 뭉갠 영역)는 인라인 style 로 채운다.
+   .mock 의 형제이므로 :has(.mock ~ .mock) 규칙에 그대로 걸려
+   zoom 과 gutter 가 전체 목업과 동일하게 적용된다. */
+.mock-partial {
+  height: 320px;
+}
+
 /* Code tags */
 code {
   background: #f1f5f9;
@@ -624,6 +635,61 @@ code {
     </div>
     <div class="ppt-footer">PROBE | Ver.0</div>
   </div>
+
+  <div class="ppt-slide" data-mockcount="2">
+    <div class="ppt-top-bar">
+      <div class="ppt-top-no">NO. 06.5</div>
+      <div class="ppt-top-title">2 mocks + 부분 목업 (팝업)</div>
+      <div class="ppt-top-proj">PROBE</div>
+    </div>
+    <div class="ppt-meta-bar">
+      <div class="ppt-meta-label">Location</div>
+      <div class="ppt-meta-value">홈 &gt; 프로브</div>
+    </div>
+    <div class="ppt-content">
+      <div class="ppt-wireframe">
+        <div class="mock">
+          <div class="mock-screen">
+            <div class="mock-status"></div>
+            <div class="mock-header"><span>HEADER</span></div>
+            <div class="mock-body" style="position:relative;">
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1-1</span>
+              <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
+              <div style="background:#eee; height:60px;">content B</div>
+            </div>
+            <div class="mock-footer">
+              <div class="mock-tab active">Home</div>
+              <div class="mock-tab">Search</div>
+            </div>
+          </div>
+          <div class="mock-caption">기본</div>
+        </div>
+        <div class="mock mock-partial">
+          <div class="mock-screen">
+            <div class="mock-status"></div>
+            <div class="mock-header"><span>HEADER</span></div>
+            <div class="mock-body" style="position:relative;">
+              <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2-1</span>
+              <div data-probe-content style="background:#eee; height:60px; margin-bottom:12px;">content A</div>
+              <div style="background:#eee; height:60px;">content B</div>
+            </div>
+            <div class="mock-footer">
+              <div class="mock-tab active">Home</div>
+              <div class="mock-tab">Search</div>
+            </div>
+          </div>
+          <div class="mock-caption">바텀시트 열림</div>
+        </div>
+      </div>
+      <div class="ppt-desc-panel">
+        <div class="ppt-desc-header">Description</div>
+        <div class="ppt-desc-body"><ul class="desc-list">
+          <li><span class="desc-num">(1)</span> <div>probe item</div></li>
+        </ul></div>
+      </div>
+    </div>
+    <div class="ppt-footer">PROBE | Ver.0</div>
+  </div>
 </div>
 
 <script>
@@ -641,7 +707,9 @@ function chk(name, actual, expected, tol){
              (typeof expected==='number'?expected.toFixed(2):String(expected)), ok?'PASS':'FAIL']);
 }
 document.querySelectorAll('.ppt-slide').forEach(function(slide){
-  var n = +slide.dataset.mockcount, tag='['+n+'-mock] ';
+  var n = +slide.dataset.mockcount;
+  var no = slide.querySelector('.ppt-top-no').textContent.replace('NO. ','');
+  var tag='['+no+' '+n+'-mock] ';
   var wf = slide.querySelector('.ppt-wireframe'), wi = inner(wf);
   chk(tag+'ppt-wireframe content width', wi.right-wi.left, 980, 1.5);
   chk(tag+'ppt-wireframe content height', wi.bottom-wi.top, 643.5, 1.5);
@@ -652,7 +720,8 @@ document.querySelectorAll('.ppt-slide').forEach(function(slide){
   mocks.forEach(function(m,i){
     var mr=r(m);
     chk(tag+'mock['+i+'] visual width', mr.width, 320*z, 1.0);
-    chk(tag+'mock['+i+'] visual height', mr.height, 600*z, 1.5);
+    var baseH = m.classList.contains('mock-partial') ? 320 : 600;
+    chk(tag+'mock['+i+'] visual height', mr.height, baseH*z, 1.5);
     chk(tag+'mock['+i+'] inside wireframe (left)', mr.left>=wi.left-0.5, true);
     chk(tag+'mock['+i+'] inside wireframe (right)', mr.right<=wi.right+0.5, true);
     if(i>0) chk(tag+'gap mock['+(i-1)+']->mock['+i+']', mr.left-r(mocks[i-1]).right, 24, 1.0);

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -78,6 +78,14 @@ description: Use when the user asks for a mobile web or app screen design docume
 - 설명 리스트는 목업 순서대로 묶어 적는다 — `1-1` `1-2` 를 먼저, 그다음 `2-1` `2-2`.
 - 목업 간 간격·정렬·축소는 템플릿이 처리한다. `ppt-wireframe` 이나 `mock` 에 인라인 `width`·`transform`·`zoom`·`margin` 을 주지 않는다.
 
+**팝업·바텀시트는 부분 목업으로 그린다.** 전체 화면 목업으로 그리면 별개 화면처럼 보이고, 본 목업 안에 인라인으로 그리면 열리기 전 상태를 함께 보여줄 수 없다.
+
+- `<div class="mock mock-partial">` 로 만든다. 높이가 줄어 화면 일부만 덮는다는 사실이 그림으로 전달된다.
+- 위쪽 배경 힌트는 인라인 `style` 로 회색 블록을 채운다 — 팝업 뒤에 화면이 있다는 표시다.
+- 배지는 **부모-자식 관계**로 매긴다. 팝업을 여는 버튼이 `2-3` 이면 팝업 자체는 `3-1` 이 아니라 여는 쪽 번호를 이어받아 표기하고, 설명에서 어느 버튼이 여는지 명시한다.
+- 팝업에도 화면 ID 를 준다. 여는 쪽 설명에 `탭 시 서류등록 바텀시트 노출 (DTC-DOC-101)` 처럼 적는다.
+- `mock-caption` 은 부분 목업에도 붙인다 — 무엇의 팝업인지 알 수 없으면 의미가 없다.
+
 # Color
 
 `template.html` 의 `:root` 에 정의된 `--accent` / `--accent-ink` 두 변수가 강조색 계약이다. `ppt-footer` 배경, `pointer-badge` 배경, `mock-tab.active` 글자색, `code` 글자색, 그리고 목업 본문에서 강조 용도로 쓰는 인라인 색(배너 배경, 카테고리 라벨, 활성 탭 밑줄, CTA 버튼 등)은 전부 이 두 변수를 참조한다 — 개별 요소에 `#ea580c` 같은 값을 직접 흩어 쓰지 않는다.
@@ -112,7 +120,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `desc-num` | 설명 항목 번호 (①②③) |
 | `pointer-badge` | 목업 위 accent 컬러 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 좌측 여백(1개 28px · 2개 이상 34px)이 배지 자리다. 폭은 내용에 맞춰 늘어난다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
 | `mock` | 모바일 목업 외곽 프레임. `ppt-wireframe` 안에 여러 개 둘 수 있다 |
-| `mock-caption` | 목업 라벨 (`기본 상태` / `선택됨`). `mock` 의 마지막 자식으로 두면 프레임 아래에 표시된다. 목업이 2개 이상이면 필수 || `mock-screen` | 목업 화면 |
+| `mock-caption` | 목업 라벨 (`기본 상태` / `선택됨`). `mock` 의 마지막 자식으로 두면 프레임 아래에 표시된다. 목업이 2개 이상이면 필수 |
+| `mock-partial` | 부분 목업(팝업·바텀시트). `mock` 과 **함께** 쓴다 — `class="mock mock-partial"` |
+| `mock-screen` | 목업 화면 |
 | `mock-status` | 목업 상태바 |
 | `mock-header` | 목업 헤더 |
 | `mock-body` | 목업 본문 |
@@ -212,7 +222,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 ## 화면 상세 — 목업 2개 (상태 비교)
 
-좌측 패널에 `mock` 을 나란히 두고 각각 `mock-caption` 으로 라벨을 붙인다. 배지 번호는 슬라이드 단위로 이어진다 — 첫 목업이 `1`·`2`, 두 번째 목업이 `3`. 축소율과 간격은 템플릿이 처리하므로 인라인으로 크기를 주지 않는다.
+좌측 패널에 `mock` 을 나란히 두고 각각 `mock-caption` 으로 라벨을 붙인다. 배지 번호는 2단이다 — 첫 목업이 `1-1`·`1-2`, 두 번째 목업이 `2-1`. 축소율과 간격은 템플릿이 처리하므로 인라인으로 크기를 주지 않는다.
 
 ```html
 <div class="ppt-wireframe">
@@ -222,9 +232,9 @@ description: Use when the user asks for a mobile web or app screen design docume
       <div class="mock-status"></div>
       <div class="mock-header">필터</div>
       <div class="mock-body" style="position:relative;">
-        <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
+        <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1-1</span>
         <!-- 선택 전 목록 -->
-        <span class="pointer-badge" style="position:absolute; top:200px; left:2px; z-index:10;">2</span>
+        <span class="pointer-badge" style="position:absolute; top:200px; left:2px; z-index:10;">1-2</span>
         <!-- 적용 버튼 (비활성) -->
       </div>
     </div>
@@ -236,7 +246,7 @@ description: Use when the user asks for a mobile web or app screen design docume
       <div class="mock-status"></div>
       <div class="mock-header">필터</div>
       <div class="mock-body" style="position:relative;">
-        <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">3</span>
+        <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">2-1</span>
         <!-- 선택된 칩이 강조된 목록 -->
       </div>
     </div>
@@ -249,9 +259,9 @@ description: Use when the user asks for a mobile web or app screen design docume
   <div class="ppt-desc-header">Description (화면설명)</div>
   <div class="ppt-desc-body">
     <ul class="desc-list">
-      <li><span class="desc-num">①</span> <div><b>필터 목록 (기본 상태)</b><br>미선택 시 전체 조건 노출 <code>ChipGroup</code></div></li>
-      <li><span class="desc-num">②</span> <div><b>적용 버튼 (기본 상태)</b><br>선택 0건이면 비활성 <code>Button (disabled)</code></div></li>
-      <li><span class="desc-num">③</span> <div><b>필터 목록 (선택됨)</b><br>선택 항목 Primary 강조, 상단 고정 <code>ChipGroup (selected)</code></div></li>
+      <li><span class="desc-num">1-1</span> <div><b>필터 목록 (기본 상태)</b><br>미선택 시 전체 조건 노출 <code>ChipGroup</code></div></li>
+      <li><span class="desc-num">1-2</span> <div><b>적용 버튼 (기본 상태)</b><br>선택 0건이면 비활성 <code>Button (disabled)</code></div></li>
+      <li><span class="desc-num">2-1</span> <div><b>필터 목록 (선택됨)</b><br>선택 항목 Primary 강조, 상단 고정 <code>ChipGroup (selected)</code></div></li>
     </ul>
   </div>
 </div>

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -363,6 +363,17 @@ body {
   color: #555;
 }
 
+/* 부분 목업 — 팝업·바텀시트·토스트처럼 화면 일부만 덮는 요소.
+   .mock 과 함께 쓴다: <div class="mock mock-partial">
+   전체 화면 목업으로 그리면 별개 화면처럼 보이므로, 높이를 줄여
+   "화면 일부를 덮는다" 는 사실 자체를 그림으로 전달한다.
+   위쪽 배경 힌트(회색으로 뭉갠 영역)는 인라인 style 로 채운다.
+   .mock 의 형제이므로 :has(.mock ~ .mock) 규칙에 그대로 걸려
+   zoom 과 gutter 가 전체 목업과 동일하게 적용된다. */
+.mock-partial {
+  height: 320px;
+}
+
 /* Code tags */
 code {
   background: #f1f5f9;


### PR DESCRIPTION
## 요약

팝업·바텀시트를 부분 목업으로 표현할 수 있게 한다.

Closes #20

실무 화면설계서 레퍼런스(은행 앱 `Bravo Korea CAR LOAN`, p.78)는 `서류등록` 바텀시트를 전체 화면 목업이 아니라 **부분 목업**으로 그린다. 시트 영역만 잘라 보여주고 위쪽은 배경 화면이 회색으로 뭉개진 상태로 둔다 — 팝업이 화면 전체를 덮지 않는다는 사실 자체를 그림으로 전달한다.

기존에는 선택지가 둘뿐이었고 둘 다 부정확했다.

- 전체 화면 목업으로 그린다 → 실제로는 배경 위에 얹히는데 별개 화면처럼 보인다
- 본 목업 안에 인라인으로 그린다 → 열리기 전 상태를 함께 보여줄 수 없다

## 구현 — 클래스 하나

```css
.mock-partial { height: 320px; }
```

`.mock` 과 함께 쓴다 — `class="mock mock-partial"`. `.mock` 의 **형제**이므로 `:has(.mock ~ .mock)` 규칙에 그대로 걸려 zoom(0.9 / 0.68)과 gutter(34px)가 전체 목업과 동일하게 적용된다. 이슈 #13·#18 의 계산을 다시 하지 않아도 된다.

배경 힌트는 인라인 `style` 로 채우게 해서 클래스를 더 늘리지 않았다.

## 프로브 버그 두 개를 함께 고쳤다

부분 목업 슬라이드를 추가하니 기존 프로브의 결함이 드러났다.

1. **슬라이드 태그 충돌** — 태그가 목업 개수 기반이라 `06.2` 와 새 `06.5` 가 둘 다 `[2-mock]` 이었다. 슬라이드 번호를 태그에 넣어 `[06.2 2-mock]` / `[06.5 2-mock]` 으로 고유하게 만들었다.
2. **목업 높이 기대값 고정** — 항상 `600*z` 를 기대해 부분 목업(`320*z`)에서 실패했다. `mock-partial` 여부로 기준 높이를 나눈다.

## 검증

**156 checks ALL PASS** (기존 131 + 부분 목업 슬라이드 25).

브라우저 실측 (`06.5` 슬라이드):

| 목업 | 클래스 | 크기 | zoom |
|---|---|---|---|
| 기본 | `mock` | 288 × 540 | 0.9 |
| 바텀시트 열림 | `mock mock-partial` | 288 × **288** | 0.9 |

`ppt-wireframe` 982 × 645.5, 오버플로 없음. 캡션이 부분 목업 아래에도 정상 표시된다.

```
$ python3 -m unittest discover -s tests
Ran 24 tests in 0.005s
OK

$ ./tests/test_install.sh
pass=30 fail=0

$ git diff --exit-code examples/
(clean — 재생성 불변식 성립)

$ python3 scripts/check_output.py examples/doksam_news_storyboard.html
총 위반 0건
```

## SKILL.md

- Class Quick Reference 에 `mock-partial` 행 추가
- 부분 목업 사용 규칙 — 배경 힌트, 배지 부모-자식 관계, 팝업 화면 ID, `mock-caption` 필수
- **이슈 #18 반영 누락분 정정** — 목업 2개 마크업 예시의 배지가 아직 1단(`1`,`2`,`3`)이었다. `1-1`/`1-2`/`2-1` 로 고치고 `desc-num` 도 평문 2단으로 맞췄다. 단일 목업 예시는 원문자(①②)를 유지한다
- 병합 과정에서 개행이 빠져 한 줄로 붙어 있던 Quick Reference 표 행(`mock-caption` / `mock-screen`)을 분리했다

## PDF 레퍼런스 반영 완료

이 PR 로 이슈 #17~#20 이 모두 닫힌다.

| # | 내용 |
|---|---|
| #17 | 상단 메타 바 — `Location` |
| #18 | 배지 2단 계층 번호 |
| #19 | 전역 화면 ID 체계 |
| #20 | 팝업 부분 목업 |

레퍼런스의 버전 변경 표기(`v0.41 수정`)와 지시선은 의도적으로 제외했다. 개정 이력이 쌓인 문서에서만 의미가 있고, 매번 새로 생성하는 v1.0.0 초안에 넣으면 가짜 이력이 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
