### PR TITLE
fix: 목업 2개 이상 슬라이드에서 캡션을 화면 ID 정의 자리로 인정 (#26)

### DIFF
--- a/scripts/check_output.py
+++ b/scripts/check_output.py
@@ -29,6 +29,16 @@ TEMPLATE = REPO_ROOT / "skills" / "mobile-web-planner" / "resources" / "template
 EMOJI_RANGES = ((0x1F000, 0x1F2FF), (0x1F300, 0x1FAFF), (0x2600, 0x27BF), (0x2B00, 0x2BFF))
 
 
+def markup_only(html):
+    """<style> 블록을 걷어낸 마크업만 반환한다.
+
+    템플릿 CSS 주석에는 `<div class="mock mock-partial">` 같은 사용 예시가
+    들어 있다. 마크업 판정을 원문 전체에 대고 돌리면 그 예시를 실제 목업으로
+    세어 오탐이 난다.
+    """
+    return re.sub(r"<style\b[^>]*>.*?</style>", "", html, flags=re.S | re.I)
+
+
 def emoji_in(text):
     """텍스트에 등장하는 이모지를 원문 순서대로 반환한다."""
     return [c for c in text if any(lo <= ord(c) <= hi for lo, hi in EMOJI_RANGES)]
@@ -76,41 +86,72 @@ def mock_counts(html):
 
 
 
+ID_RE = r"\b[A-Z]{2,6}-[A-Z]{2,12}-\d{3}\b"
+
+
 def screen_ids(html):
-    """ppt-meta-id 로 정의된 화면 ID 집합을 반환한다."""
-    return set(re.findall(r'class="ppt-meta-id">([^<]+)<', html))
+    """정의된 화면 ID 집합을 반환한다.
+
+    정의 자리는 두 곳이다 — 슬라이드 대표 화면의 `ppt-meta-id`, 그리고 목업이
+    2개 이상인 슬라이드에서 각 목업의 `mock-caption`. 캡션까지 정의로 세는
+    이유는 `ppt-meta-id` 가 슬라이드당 한 칸뿐이어서 두 번째 목업의 화면 ID 를
+    담을 자리가 없기 때문이다.
+    """
+    ids = set()
+    for raw in re.findall(r'class="ppt-meta-id">([^<]+)<', html):
+        ids.update(re.findall(ID_RE, raw))
+    for raw in re.findall(r'class="mock-caption">([^<]*)<', html):
+        ids.update(re.findall(ID_RE, raw))
+    return ids
 
 
 def referenced_ids(html):
     """본문에서 언급된 화면 ID 후보를 반환한다.
 
-    형식은 <서비스약어>-<기능>-<3자리> 다. ppt-meta-id 안의 정의 자리는
-    제외하고, 설명 문장에서 참조된 것만 센다.
+    형식은 <서비스약어>-<기능>-<3자리> 다. 정의 자리(ppt-meta-id 와
+    mock-caption)는 제외하고, 설명 문장에서 참조된 것만 센다.
     """
     stripped = re.sub(r'class="ppt-meta-id">[^<]+<', 'class="ppt-meta-id"><', html)
-    return set(re.findall(r"\b([A-Z]{2,6}-[A-Z]{2,12}-\d{3})\b", stripped))
+    stripped = re.sub(r'class="mock-caption">[^<]*<', 'class="mock-caption"><', stripped)
+    return set(re.findall(ID_RE, stripped))
+
+
+
+def meta_locations(html):
+    """06.x 슬라이드의 (번호, Location) 을 반환한다."""
+    out = []
+    for m in re.finditer(r"NO\.\s*(06\.\d+)(.*?)(?=NO\.\s*06\.|\Z)", html, re.S):
+        loc = re.search(r'class="ppt-meta-value">([^<]*)<', m.group(2))
+        out.append((m.group(1), loc.group(1).strip() if loc else ""))
+    return out
+
+
+def badge_labels(html):
+    """pointer-badge 라벨을 반환한다."""
+    return re.findall(r'class="pointer-badge"[^>]*>([^<]+)<', html)
 
 
 def check(path, css):
     """한 산출물을 판정해 (위반 목록, 정보 목록) 을 반환한다."""
     html = Path(path).read_text(encoding="utf-8")
+    markup = markup_only(html)
     violations, info = [], []
 
     undefined = gd.undefined_classes(html, css)
     if undefined:
         violations.append(f"미정의 클래스 {len(undefined)}종: {', '.join(undefined)}")
 
-    emoji = emoji_in(html)
+    emoji = emoji_in(markup)
     if emoji:
         kinds = sorted(set(emoji))
         violations.append(f"이모지 {len(emoji)}개 / {len(kinds)}종: {''.join(kinds)}")
 
-    lefts = badge_lefts(html)
+    lefts = badge_lefts(markup)
     off = sorted({v for v in lefts if v != 2})
     if off:
         violations.append(f"배지 left 가 2px 아닌 값 {off} (전체 {len(lefts)}개 중)")
 
-    mism = badge_desc_mismatch(html)
+    mism = badge_desc_mismatch(markup)
     if mism:
         detail = ", ".join(f"{no}({b}/{d})" for no, b, d in mism)
         violations.append(f"배지-desc_num 불일치: {detail}")
@@ -121,26 +162,39 @@ def check(path, css):
     if "{{" in html:
         violations.append(f"치환 안 된 플레이스홀더 {html.count('{{')}건")
 
-    defined = screen_ids(html)
-    dangling = sorted(referenced_ids(html) - defined)
+    defined = screen_ids(markup)
+    dangling = sorted(referenced_ids(markup) - defined)
     if defined and dangling:
         violations.append(
             f"정의되지 않은 화면 ID 를 참조한다: {', '.join(dangling)}"
         )
 
-    nums = slide_numbers(html)
+    nums = slide_numbers(markup)
     info.append(f"슬라이드 {len(nums)}장: {' '.join(nums)}")
     info.append(f"크기 {len(html):,} bytes / 배지 {len(lefts)}개")
     accent = re.search(r"--accent:\s*([^;]+);", html)
     info.append(f"accent {accent.group(1).strip() if accent else '변수 없음'}")
 
-    order = screen_order(html)
+    order = screen_order(markup)
     info.append("화면 순서: " + " / ".join(f"{n} {t.strip()}" for n, t in order))
     if defined:
         info.append(f"화면 ID {len(defined)}개: {' '.join(sorted(defined))}")
-    mocks = mock_counts(html)
+    mocks = mock_counts(markup)
     multi = [f"{n}({c})" for n, c in mocks if c >= 2]
     info.append(f"목업 2개 이상 슬라이드 {len(multi)}개" + (f": {' '.join(multi)}" if multi else ""))
+
+    locs = meta_locations(markup)
+    filled = [n for n, v in locs if v]
+    info.append(f"Location {len(filled)}/{len(locs)} 슬라이드"
+                + (f" (미기입 {', '.join(n for n, v in locs if not v)})" if len(filled) != len(locs) else ""))
+
+    # class 속성만 센다 — 본문 텍스트나 CSS 주석에 등장하는 같은 문자열은 목업이 아니다.
+    partial = len(re.findall(r'class="[^"]*\bmock-partial\b[^"]*"', markup))
+    info.append(f"부분 목업(팝업) {partial}개")
+
+    labels = badge_labels(markup)
+    two = [x for x in labels if "-" in x]
+    info.append(f"2단 배지 {len(two)}/{len(labels)}개")
     return violations, info
 
 

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -76,6 +76,8 @@ description: Use when the user asks for a mobile web or app screen design docume
 - **`pointer-badge` 번호는 2단이다** — `<목업번호>-<요소번호>`. 첫 목업의 요소는 `1-1` `1-2`, 두 번째 목업은 `2-1` `2-2` 로 매긴다. 목업이 몇 번째인지가 번호에서 바로 읽히므로 "어느 목업의 항목인지" 를 따로 적을 필요가 없다.
 - **`desc-num` 도 같은 2단 표기를 쓴다.** 원문자(①②③)는 2단을 표현할 수 없으므로 목업이 2개 이상인 슬라이드에서는 `1-1` 처럼 평문으로 적는다. 목업이 1개면 지금처럼 원문자를 쓴다.
 - 설명 리스트는 목업 순서대로 묶어 적는다 — `1-1` `1-2` 를 먼저, 그다음 `2-1` `2-2`.
+- **각 목업의 화면 ID 는 `mock-caption` 에 이름과 함께 적는다** — `<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>`. 목업이 2개면 화면도 2개인데 `ppt-meta-id` 는 슬라이드에 한 칸뿐이므로, 두 번째 화면의 ID 는 캡션이 정의 자리다. 캡션에 안 적으면 설명에서 `(DTC-BOARD-002)` 로 참조해도 문서 안에 정의가 없는 끊어진 참조가 된다.
+- **`ppt-meta-id` 에는 그 슬라이드의 대표 화면, 즉 첫 목업의 ID 를 둔다.** `ppt-meta-value` 의 위치도 첫 목업 기준으로 적는다.
 - 목업 간 간격·정렬·축소는 템플릿이 처리한다. `ppt-wireframe` 이나 `mock` 에 인라인 `width`·`transform`·`zoom`·`margin` 을 주지 않는다.
 
 **팝업·바텀시트는 부분 목업으로 그린다.** 전체 화면 목업으로 그리면 별개 화면처럼 보이고, 본 목업 안에 인라인으로 그리면 열리기 전 상태를 함께 보여줄 수 없다.
@@ -94,7 +96,9 @@ description: Use when the user asks for a mobile web or app screen design docume
 - **도메인에 맞는 색을 고른다.** 예: 스포츠/동호회 = 코트 그린, 뉴스 = 뉴트럴 블루, 쇼핑 = 웜 레드. 요청에 브랜드 컬러가 주어지면 그것을 우선한다.
 - **명도 대비를 확인한다.** `--accent` 배경 위에 `--accent-ink` 글자가 얹힌다 (`ppt-footer`, `pointer-badge`, 목업 배너 등). 밝은 accent(예: 라임, 파스텔)를 고르면 `--accent-ink` 를 어두운 색(예: `#1a1a1a`)으로 함께 바꿔 가독성을 유지한다.
 - **상태색은 별개다.** 참석 초록 / 마감 회색처럼 의미 고정 상태색은 accent 와 분리해 `05 General Rule` 슬라이드에 문서화한다. accent 변수를 상태색 용도로 재사용하지 않는다.
-- **프레임 색은 고정이다.** 슬라이드 캔버스(`#e5e7eb`), 상단 번호 블록·설명 패널 헤더의 회색(`#737373`), 목업 내부의 상태바/구분선 회색(`#f4f4f5`, `#e2e8f0`, `#94a3b8` 등)은 이 스킬이 "정통 PPT 화면설계서"로 읽히게 하는 고정 프레임이므로 변수화 대상이 아니다. 바꾸지 않는다.# Class Quick Reference
+- **프레임 색은 고정이다.** 슬라이드 캔버스(`#e5e7eb`), 상단 번호 블록·설명 패널 헤더의 회색(`#737373`), 목업 내부의 상태바/구분선 회색(`#f4f4f5`, `#e2e8f0`, `#94a3b8` 등)은 이 스킬이 "정통 PPT 화면설계서"로 읽히게 하는 고정 프레임이므로 변수화 대상이 아니다. 바꾸지 않는다.
+
+# Class Quick Reference
 
 `resources/template.html` 에 정의된 클래스만 사용한다. **이 표에 없는 클래스를 새로 만들지 않는다.** 목업 내부의 세부 스타일은 인라인 `style` 속성으로 처리한다.
 
@@ -120,7 +124,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 | `desc-num` | 설명 항목 번호 (①②③) |
 | `pointer-badge` | 목업 위 accent 컬러 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 좌측 여백(1개 28px · 2개 이상 34px)이 배지 자리다. 폭은 내용에 맞춰 늘어난다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
 | `mock` | 모바일 목업 외곽 프레임. `ppt-wireframe` 안에 여러 개 둘 수 있다 |
-| `mock-caption` | 목업 라벨 (`기본 상태` / `선택됨`). `mock` 의 마지막 자식으로 두면 프레임 아래에 표시된다. 목업이 2개 이상이면 필수 |
+| `mock-caption` | 목업 라벨. `mock` 의 마지막 자식으로 두면 프레임 아래에 표시된다. 목업이 2개 이상이면 필수이고, 라벨과 함께 그 목업의 화면 ID 를 적는다 — `필터 선택됨 (DTC-FILTER-002)` |
 | `mock-partial` | 부분 목업(팝업·바텀시트). `mock` 과 **함께** 쓴다 — `class="mock mock-partial"` |
 | `mock-screen` | 목업 화면 |
 | `mock-status` | 목업 상태바 |
@@ -144,7 +148,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 5. **화면 순서** — `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `06.x` 슬라이드 순서 세 곳이 같은가. 그리고 그 순서가 사용자가 기능을 나열한 순서와 같은가(진입 화면은 `06.1`). 다르면 사용자 나열 순서를 기준으로 세 곳을 함께 맞춘다.
 6. **목업 개수** — `06.x` 마다 목업 트리거 표(위 `## 목업 여러 개 배치`)를 대조한다. 트리거에 해당하는데 `mock` 이 1개면 2개로 늘리고 `mock-caption` 을 붙인다. 해당하지 않는데 2개면 1개로 줄인다.
 7. **화면 위치** — `06.x` 마다 `ppt-meta-bar` 가 있고 값이 `04 IA` 의 경로와 맞는가. `01`~`05` 에는 없어야 한다.
-8. **화면 ID** — `06.x` 마다 `ppt-meta-id` 가 있는가. 본문에서 참조한 ID 가 모두 이 문서에 정의되어 있는가. 정의 없는 ID 를 가리키면 그 화면을 추가하거나 참조를 고친다.
+8. **화면 ID** — `06.x` 마다 `ppt-meta-id` 가 있는가. 목업이 2개 이상인 슬라이드는 각 `mock-caption` 에도 그 목업의 ID 가 적혀 있는가. 본문에서 참조한 ID 를 모아 `ppt-meta-id` 와 `mock-caption` 에 정의된 ID 집합과 대조한다 — 어느 쪽에도 없는 ID 가 하나라도 있으면 그 화면을 추가하거나 참조를 고친다.
 
 # Icons
 
@@ -222,7 +226,7 @@ description: Use when the user asks for a mobile web or app screen design docume
 
 ## 화면 상세 — 목업 2개 (상태 비교)
 
-좌측 패널에 `mock` 을 나란히 두고 각각 `mock-caption` 으로 라벨을 붙인다. 배지 번호는 2단이다 — 첫 목업이 `1-1`·`1-2`, 두 번째 목업이 `2-1`. 축소율과 간격은 템플릿이 처리하므로 인라인으로 크기를 주지 않는다.
+좌측 패널에 `mock` 을 나란히 두고 각각 `mock-caption` 으로 라벨을 붙인다. 배지 번호는 2단이다 — 첫 목업이 `1-1`·`1-2`, 두 번째 목업이 `2-1`. 축소율과 간격은 템플릿이 처리하므로 인라인으로 크기를 주지 않는다. 캡션에는 라벨과 함께 그 목업의 화면 ID 를 적어 두 번째 화면의 ID 도 문서 안에 정의된다.
 
 ```html
 <div class="ppt-wireframe">
@@ -238,7 +242,7 @@ description: Use when the user asks for a mobile web or app screen design docume
         <!-- 적용 버튼 (비활성) -->
       </div>
     </div>
-    <div class="mock-caption">기본 상태</div>
+    <div class="mock-caption">필터 기본 (DTC-FILTER-001)</div>
   </div>
 
   <div class="mock">
@@ -250,7 +254,7 @@ description: Use when the user asks for a mobile web or app screen design docume
         <!-- 선택된 칩이 강조된 목록 -->
       </div>
     </div>
-    <div class="mock-caption">선택됨</div>
+    <div class="mock-caption">필터 선택됨 (DTC-FILTER-002)</div>
   </div>
 
 </div>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -231,6 +231,12 @@ class TestCheckOutputScreenIds(unittest.TestCase):
         html = '<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>'
         self.assertEqual(self.co.screen_ids(html), {"DTC-BOARD-002"})
 
+    def test_meta_id_may_hold_several_ids(self):
+        """런타임이 두 화면을 한 칸에 묶어 적어도 각각 정의로 읽는다."""
+        html = '<div class="ppt-meta-id">DTC-BOARD-001 / DTC-BOARD-002</div>'
+        self.assertEqual(self.co.screen_ids(html),
+                         {"DTC-BOARD-001", "DTC-BOARD-002"})
+
     def test_caption_definition_is_not_counted_as_a_reference(self):
         html = ('<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>'
                 '<div>글 상세로 이동 (DTC-BOARD-003)</div>')

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -211,3 +211,57 @@ class TestSkillClassQuickReference(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCheckOutputScreenIds(unittest.TestCase):
+    """check_output.py 의 화면 ID 정의/참조 판정 (이슈 #26)."""
+
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import check_output
+        cls.co = check_output
+
+    def test_meta_id_is_a_definition(self):
+        html = '<div class="ppt-meta-id">DTC-MAIN-001</div>'
+        self.assertEqual(self.co.screen_ids(html), {"DTC-MAIN-001"})
+
+    def test_caption_id_is_a_definition(self):
+        """목업 2개짜리 슬라이드의 두 번째 화면 ID 는 캡션이 정의 자리다."""
+        html = '<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>'
+        self.assertEqual(self.co.screen_ids(html), {"DTC-BOARD-002"})
+
+    def test_caption_definition_is_not_counted_as_a_reference(self):
+        html = ('<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>'
+                '<div>글 상세로 이동 (DTC-BOARD-003)</div>')
+        self.assertEqual(self.co.referenced_ids(html), {"DTC-BOARD-003"})
+
+    def test_reference_defined_only_in_caption_is_not_dangling(self):
+        html = ('<div class="ppt-meta-id">DTC-BOARD-001</div>'
+                '<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>'
+                '<div>탭 시 글 상세로 이동 (DTC-BOARD-002)</div>')
+        dangling = self.co.referenced_ids(html) - self.co.screen_ids(html)
+        self.assertEqual(dangling, set())
+
+
+class TestCheckOutputIgnoresStyleBlock(unittest.TestCase):
+    """CSS 주석의 사용 예시를 실제 마크업으로 세지 않는다 (이슈 #26)."""
+
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import check_output
+        cls.co = check_output
+
+    def test_markup_only_drops_style_block(self):
+        html = '<style>/* <div class="mock mock-partial"> */</style><div class="mock"></div>'
+        self.assertNotIn("mock-partial", self.co.markup_only(html))
+        self.assertIn('class="mock"', self.co.markup_only(html))
+
+    def test_partial_mock_in_css_comment_is_not_counted(self):
+        template = (REPO_ROOT / "skills" / "mobile-web-planner"
+                    / "resources" / "template.html").read_text(encoding="utf-8")
+        self.assertIn('class="mock mock-partial"', template,
+                      "템플릿 CSS 주석의 사용 예시가 사라졌다면 이 테스트의 전제가 깨진다")
+        css = gd.extract_style(template)
+        self.assertNotIn("mock-partial", self.co.markup_only(f"<style>{css}</style>"))


### PR DESCRIPTION
Closes #26

## 무엇을 고쳤나

목업 2개 이상인 `06.x` 슬라이드에서 두 번째 화면의 ID 를 정의할 자리가 없던 문제를 `mock-caption` 을 정의 자리로 삼아 해결한다.

## 왜 캡션인가

캡션은 이미 "이 목업이 무엇인지" 를 적는 자리다. 그 화면의 ID 를 함께 두면 의미가 겹치지 않고, 새 클래스도 CSS 변경도 필요 없다. Antigravity 산출물이 규약 없이도 스스로 이 형태를 골랐다.

```html
<div class="mock-caption">게시판 목록 (DTC-BOARD-001)</div>
<div class="mock-caption">게시글 상세 (DTC-BOARD-002)</div>
```

`ppt-meta-id` 는 슬라이드 대표 화면(첫 목업)의 ID 를 갖는다고 명시했다.

## 함께 고친 검사기 오탐

`check_output.py` 가 마크업 판정을 HTML 원문 전체에 돌리고 있었다. 템플릿 CSS 주석에는 사용 예시가 들어 있어서

```
/* 부분 목업 — ... .mock 과 함께 쓴다: <div class="mock mock-partial"> */
```

이 주석 한 줄이 실제 부분 목업으로 집계됐다. 부분 목업이 하나도 없는 뉴스 예시 문서가 `부분 목업(팝업) 1개` 로 보고되고 있었다. 마크업 판정 전에 `<style>` 블록을 제거하도록 바꿨다.

## 검증

| 항목 | 결과 |
|---|---|
| 단위 테스트 | 30개 (신규 6개) OK |
| `tests/test_install.sh` | pass=30 fail=0 |
| 재생성 불변식 | `git diff --exit-code examples/` clean |
| 라운드 4 Antigravity 산출물 | 위반 1건 → **0건**, 화면 ID 7개 → 12개 인식 |
| 뉴스 예시 문서 | 부분 목업 1개(오탐) → **0개** |

신규 테스트는 정의/참조 구분(캡션 ID 는 정의로 세고 참조로는 세지 않음)과 CSS 주석 무시를 각각 고정한다. 후자는 템플릿에 그 주석이 실제로 남아 있는지도 함께 단언해, 주석이 사라지면 테스트가 전제 붕괴를 알린다.

## 두 런타임이 서로 다른 해법을 냈다

같은 요청에 Antigravity 와 Codex 가 각자 다른 방식으로 두 번째 화면 ID 를 표기했다.

| 런타임 | 표기 방식 |
|---|---|
| Antigravity | `mock-caption` 에 `게시글 상세 (DTC-BOARD-002)` |
| Codex | `ppt-meta-id` 에 `DTC-BOARD-001 / DTC-BOARD-002` |

수정된 `screen_ids` 는 두 자리 모두에서 정규식으로 ID 를 추출하므로 둘 다 12개로 읽는다. 수정 전에는 양쪽 다 위반 1건이었다 — Codex 쪽은 필드 전체를 ID 하나로 취급해서 10개가 미정의로 잡혔다.

SKILL.md 는 캡션 방식을 규약으로 정한다. 어느 ID 가 어느 목업인지가 그림 옆에서 바로 읽히기 때문이다. 검사기는 두 형태를 모두 받아들이고, 각각 테스트로 고정했다.

## 라운드 4 세 런타임 비교 (수정 후)

| 항목 | Antigravity | Codex |
|---|---|---|
| 슬라이드 | 12장 | 12장 |
| `06.x` 순서 | 나열 순서 일치 | 나열 순서 일치 |
| accent | `#15803d` | `#0f7a3d` |
| Location | 7/7 | 7/7 |
| 화면 ID | 12개 | 12개 |
| 목업 2개 슬라이드 | 5장 | 5장 |
| 2단 배지 | 27/36 | 30/39 |
| 계약 위반 | 0건 | 0건 |
