### PR TITLE
fix: 모바일에서 슬라이드 전체가 화면 폭에 맞게 축소되도록 뷰포트 고정 (#33)

### DIFF
--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -2,7 +2,10 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- 고정 레이아웃 뷰포트: 모바일 브라우저가 1280px 로 렌더한 전체 페이지를
+     화면 폭에 맞게 축소해, PPT 슬라이드를 세로 스크롤로 넘겨보는 형태가 된다.
+     내부 요소가 px 고정이라 device-width 로 두면 슬라이드 내부가 깨진다. -->
+<meta name="viewport" content="width=1280">
 <title>Classic PPT Wireframe Template</title>
 <link rel="preconnect" href="https://cdn.jsdelivr.net">
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>


### PR DESCRIPTION
## 변경

`skills/mobile-web-planner/resources/template.html` 의 viewport 메타 한 줄.

```diff
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=1280">
```

슬라이드 내부 요소가 px 고정이라 `device-width` 로 두면 모바일 화면폭(~360px) 이 레이아웃 기준이 되어 목업·배지·설명 패널이 밀리거나 겹친다. 고정 뷰포트로 두면 모바일 브라우저가 데스크톱과 동일하게 1280px 로 렌더한 뒤 페이지 전체를 축소하므로, PPT 슬라이드를 세로 스크롤로 넘겨보는 형태가 된다. 데스크톱 브라우저는 viewport 메타를 무시하므로 영향이 없다.

의도를 잃지 않도록 해당 줄 위에 주석으로 근거를 남겼다.

## 검증

현재 main 에 리베이스한 상태로 테스트를 돌려 확인했다.

```
python3 -m unittest discover -s tests   → Ran 47 tests, OK
```

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
