### PR TITLE
chore: skills.sh 배포 준비 — LICENSE·저장소 메타데이터·npx 설치 안내 (#35)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dok123
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Claude Code, Codex, Antigravity에서 **모바일 웹/앱 UX/UI 수석 기획자
 사용할 수 있게 하는 공통 Skill과 플랫폼별 Agent Adapter 패키지입니다.
 뉴스뿐만 아니라 쇼핑몰, 커뮤니티, O2O 예약 서비스 등 **모든 도메인의 모바일 기획**을 완벽하게 수행할 수 있도록 설계되었습니다.
 
+## 설치 (Install)
+
+[skills.sh](https://www.skills.sh) 생태계의 `skills` CLI 로 바로 설치할 수 있습니다.
+
+```bash
+npx skills add leeyudok/mobile-web-planner-agent
+```
+
+저장소를 클론해 두고 쓰려면 `install.sh` 를 씁니다. 이쪽은 기본이 심링크
+설치라 저장소에서 `SKILL.md` 를 고치면 런타임에 즉시 반영되고, 이름 있는
+Agent Adapter 설치(`--with-agent`)와 프로젝트 단위 설치(`--project`)를
+지원합니다. 자세한 내용은 아래 [사용 방법](#사용-방법-how-to-use) 을 보세요.
+
+```bash
+git clone https://github.com/leeyudok/mobile-web-planner-agent.git
+cd mobile-web-planner-agent
+./install.sh
+```
+
 ## 쉽게 사용
 
 ```text
@@ -211,3 +230,8 @@ mermaid 런타임 · 치환 안 된 플레이스홀더를 검사하고, 짝을 �
 ```bash
 python3 <skill-path>/scripts/validate_storyboard.py <생성된파일.html>
 ```
+
+## 라이선스
+
+[MIT](LICENSE)
+


### PR DESCRIPTION
## 배경

[skills.sh](https://www.skills.sh) 는 별도 등록 절차가 없다. 공개 저장소에 `skills/<이름>/SKILL.md` 가 있으면 `npx skills add <owner>/<repo>` 로 설치되고, 디렉터리·리더보드 노출은 설치 텔레메트리로 집계된다. 이 저장소는 구조 요건을 이미 충족하고 있었으므로, 남이 설치 여부를 판단할 근거를 채운다.

## 변경

### LICENSE (MIT) 추가

GitHub API 기준 `license: null` 이었다. 라이선스가 없는 저장소는 저작권법상 사용 허가가 없는 상태라, 스킬을 자기 환경에 설치하려는 사람에게 차단 요인이 된다.

### README 에 `npx skills` 설치 경로 추가

기존에는 클론 후 `./install.sh` 만 안내했다. skills.sh 생태계의 표준 설치 경로를 최상단에 싣고, 두 경로의 차이를 적었다.

```bash
npx skills add leeyudok/mobile-web-planner-agent
```

`install.sh` 는 심링크 설치(저장소 수정이 런타임에 즉시 반영), `--with-agent`(이름 있는 Agent Adapter), `--project`(프로젝트 단위 설치)를 지원하므로 병기한다. 하단에 라이선스 섹션도 추가했다.

### 저장소 메타데이터 (PR 밖, API 로 적용 완료)

`description` 이 빈 문자열, `topics` 가 `[]` 였다.

- description: `모바일 웹/앱 UX/UI 수석 기획자 스킬 — Claude Code · Codex · Antigravity 에서 IA 와 PPT 스타일 화면설계서(HTML)를 생성합니다`
- topics: `agent-skills, antigravity, claude-code, codex, information-architecture, mobile-web, skills, storyboard, ux-design, wireframe`

## 검증

```
python3 -m unittest discover -s tests   → Ran 47 tests, OK
./tests/test_install.sh                 → pass=47 fail=0
```

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
