### PR TITLE
feat: memory-factcheck 스킬 흡수 — 멀티 스킬 리포 전환 (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 이 문서는 AI 에이전트(Gemini, Claude 등)가 이 저장소(Repository)에서 작업할 때 지켜야 할 규칙과 프로젝트 컨텍스트를 정의합니다. `GEMINI.md`, `CLAUDE.md` 등에서 이 파일을 참조합니다.
 
 ## 1. 프로젝트 개요 (Project Context)
+- **성격**: 이 저장소는 Agent Skill 모음(doksam-skills)입니다. `skills/` 아래 스킬 하나가 배포 단위이며, `install.sh` 가 전부를 심링크로 노출합니다. 아래 지침은 주력 스킬인 mobile-web-planner 기준이고, 다른 스킬(예: `skills/memory-factcheck`)은 각자의 `SKILL.md` 가 명세입니다.
 - **목적**: Google Antigravity 등 범용 AI 에이전트를 '모바일 웹/앱 UX/UI 수석 기획자'로 동작하게 만드는 커스텀 스킬 패키지입니다.
 - **핵심 역할**: 사용자의 요청(예: "쇼핑몰 기획해줘")에 따라 IA 및 화면 설계서(HTML 기반 스토리보드)를 자동 생성합니다.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# Mobile Web Planner Agent
+# doksam-skills
 
-Claude Code, Codex, Antigravity에서 **모바일 웹/앱 UX/UI 수석 기획자**를
-사용할 수 있게 하는 공통 Skill과 플랫폼별 Agent Adapter 패키지입니다.
+Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `install.sh` 가 `skills/` 아래 모든 스킬을 세 런타임 경로에 노출합니다.
+
+| 스킬 | 설명 |
+|---|---|
+| [mobile-web-planner](skills/mobile-web-planner/SKILL.md) | 모바일 웹/앱 UX/UI 수석 기획자 — 모든 도메인의 화면설계서(스토리보드)와 Business Rules 를 생성. 플랫폼별 Agent Adapter 포함 |
+| [memory-factcheck](skills/memory-factcheck/SKILL.md) | 에이전트 영속 메모리를 코드·DB·이슈 등 실제 근거와 대조해 낡은 기억을 교정하는 감사 스킬 |
+
+## Mobile Web Planner
+
 뉴스뿐만 아니라 쇼핑몰, 커뮤니티, O2O 예약 서비스 등 **모든 도메인의 모바일 기획**을 완벽하게 수행할 수 있도록 설계되었습니다.
 
 ## 설치 (Install)
@@ -107,6 +114,8 @@ Antigravity 로컬 환경에서는 같은 요청이 `mobile-web-planner` Skill�
 ```text
 doksam-skills
 ├── skills
+│   ├── memory-factcheck
+│   │   └── SKILL.md                     메모리 팩트체크 감사 스킬
 │   └── mobile-web-planner
 │       ├── SKILL.md                     공통 Agent Workflow와 클래스 계약
 │       ├── agents

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# mobile-web-planner 스킬을 Claude Code / Codex / Gemini(Antigravity) 가
-# 인식하는 경로에 노출한다. 기본은 심링크이므로 이 레포에서 SKILL.md 를
+# 이 레포의 skills/ 아래 모든 스킬을 Claude Code / Codex / Gemini(Antigravity)
+# 가 인식하는 경로에 노출한다. 기본은 심링크이므로 이 레포에서 SKILL.md 를
 # 수정하면 세 런타임에 즉시 반영된다.
 set -uo pipefail
 
-SKILL_NAME="mobile-web-planner"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SRC="$REPO_ROOT/skills/$SKILL_NAME"
+SKILL_NAMES=()
+for d in "$REPO_ROOT"/skills/*/; do
+  [[ -f "$d/SKILL.md" ]] && SKILL_NAMES+=("$(basename "$d")")
+done
 CLAUDE_AGENT_SRC="$REPO_ROOT/.claude/agents/mobile-web-planner.md"
 CODEX_AGENT_SRC="$REPO_ROOT/.codex/agents/mobile_web_planner.toml"
 ANTIGRAVITY_AGENT_SRC="$REPO_ROOT/.agents/AGENTS.md"
@@ -87,13 +89,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ ! -d "$SRC" ]]; then
-  echo "오류: 스킬 원본이 없다 — $SRC" >&2
+if [[ ${#SKILL_NAMES[@]} -eq 0 ]]; then
+  echo "오류: skills/ 아래에 SKILL.md 를 가진 스킬이 없다" >&2
   exit 1
 fi
 
 # 타깃 목록 구성
-targets=()
+target_bases=()
 agent_sources=()
 agent_targets=()
 if [[ -n "$PROJECT" ]]; then
@@ -107,8 +109,7 @@ if [[ -n "$PROJECT" ]]; then
   fi
   # Antigravity 의 프로젝트 customization root 는 .agents/ 이고 Codex 와 같은
   # 경로이므로, 두 타깃으로 세 런타임을 모두 커버한다.
-  targets+=("$project_abs/.claude/skills/$SKILL_NAME")
-  targets+=("$project_abs/.agents/skills/$SKILL_NAME")
+  target_bases=("$project_abs/.claude/skills" "$project_abs/.agents/skills")
   if [[ $WITH_AGENT -eq 1 ]]; then
     agent_sources+=("$CLAUDE_AGENT_SRC" "$CODEX_AGENT_SRC")
     agent_targets+=(
@@ -117,11 +118,9 @@ if [[ -n "$PROJECT" ]]; then
     )
   fi
 else
-  targets+=("$HOME/.agents/skills/$SKILL_NAME")
-  targets+=("$HOME/.claude/skills/$SKILL_NAME")
   # Antigravity 의 전역 customization root 는 ~/.gemini/config/ 다.
   # ~/.gemini/antigravity/skills/ 는 agy 가 탐색하지 않는다 (이슈 #5).
-  targets+=("$HOME/.gemini/config/skills/$SKILL_NAME")
+  target_bases=("$HOME/.agents/skills" "$HOME/.claude/skills" "$HOME/.gemini/config/skills")
   if [[ $WITH_AGENT -eq 1 ]]; then
     agent_sources+=("$CLAUDE_AGENT_SRC" "$CODEX_AGENT_SRC")
     agent_targets+=(
@@ -220,12 +219,15 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "(dry-run — 파일시스템을 바꾸지 않는다)"
 fi
 
-for target in "${targets[@]}"; do
-  if [[ "$ACTION" == "uninstall" ]]; then
-    do_uninstall "$target" "$SRC"
-  else
-    do_install "$target" "$SRC"
-  fi
+for skill in "${SKILL_NAMES[@]}"; do
+  src="$REPO_ROOT/skills/$skill"
+  for base in "${target_bases[@]}"; do
+    if [[ "$ACTION" == "uninstall" ]]; then
+      do_uninstall "$base/$skill" "$src"
+    else
+      do_install "$base/$skill" "$src"
+    fi
+  done
 done
 
 if [[ $WITH_AGENT -eq 1 ]]; then

--- a/skills/memory-factcheck/SKILL.md
+++ b/skills/memory-factcheck/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: memory-factcheck
+description: Fact-check an agent's persistent memory against ground truth — verify each memory's load-bearing claims against code, database, issue tracker and filesystem, correct the stale ones, and report dead ones as archive candidates. Use when memory grows past ~30 files, right after a big stack/infra change (library swap, version upgrade, server migration, schema drop), when two memories seem to contradict each other, or on a "clean up / audit my memory" request.
+---
+
+# Memory Fact-Check
+
+Memory decays. A fact that was true when written becomes false as code, schema and
+infrastructure move on. **Stale memory is worse than no memory** — an agent reads it and
+confidently does the wrong thing.
+
+This is **not** a structural hygiene pass. Orphan files, duplicate entries, index bloat,
+broken internal links — those checks compare memory files *to each other*. This skill
+compares each memory **to the world it describes**: the code, the database, the issue
+tracker, the filesystem. A memory can be perfectly well-formed, correctly indexed, recently
+touched — and completely false.
+
+Automatic deletion is forbidden. Only a source-of-truth comparison can tell what is dead,
+and losing an incident lesson is expensive. Hence semi-automatic: **correct freely, archive
+only with approval, never delete.**
+
+## 1. Locate and inventory
+
+Find the memory set. Common locations, in order:
+
+- a path declared by the project's agent instructions (`AGENTS.md` / `CLAUDE.md` — e.g.
+  "memory SSOT is `.claude/memory/`"). A declared path wins over every default.
+- `.claude/memory/` in the repo (team-shared, committed)
+- the host's per-project memory dir (e.g. `~/.claude/projects/<slug>/memory/`)
+
+Collect for each file: frontmatter (`name`/`description`/`type`), and last modification date
+(`git log -1 --format=%cs -- <file>` for committed memory, `stat` otherwise). Note the index
+file (`MEMORY.md`) if one exists — it is audited too, but it is an index, not a memory.
+
+**Personal files are out of scope** — anything the project marks personal (`user_*.md` or
+equivalent) belongs to its owner. Leave untouched.
+
+**Reading many files**: dumping 50 memories into context at once blows the tool output cap
+and wastes the budget. Concatenate to one scratch file with `########## <filename>` headers,
+then page through it. Do not skim — a stale claim is usually one clause inside an otherwise
+correct paragraph.
+
+## 2. Extract load-bearing claims
+
+Per file, pick the **1–3 claims that change what an agent would do**. Ignore prose, rationale
+and background; a memory is only as stale as its actionable assertions.
+
+Load-bearing looks like: "X lives at path P" · "table T has N rows" · "issue #N is still open"
+· "feature F does not exist yet" · "library L is not installed" · "the fix for this is still
+pending" · "run command C to verify".
+
+## 3. Verify against the source of truth
+
+Work **cheapest-and-highest-yield first**. In practice the ranking below holds: issue status
+is one API call and catches the largest share of stale claims, because memories are written
+mid-work and the work then finishes without anyone going back to edit the memory.
+
+| Order | Claim type | How to verify |
+| --- | --- | --- |
+| 1 | **Issue/PR state** ("#N open", "waiting on #N", "decision pending") | forge CLI/API — `gh issue view N --json state` / `glab api projects/<enc>/issues/N`. Batch them in one loop |
+| 2 | **Path/URL** (script locations, deploy paths, endpoints) | `ls`, `test -f`, `curl -s -o /dev/null -w '%{http_code}'` |
+| 3 | **Code** (file/class/config exists, behaves a certain way) | `grep`/`Read` the current tree — *the code is the SoT, not the memory* |
+| 4 | **Data/schema** (tables, columns, row counts) | read-only queries via the project's DB tool. Prefer catalog estimates first (`pg_class.reltuples`, `information_schema.columns`), exact `count(*)` only when the estimate is the disputed claim |
+| 5 | **Runtime/host** (cron jobs, services, logs) | `ssh <host> 'ls …; crontab -l; tail <log>'` — a job's last log line dates the claim precisely |
+
+Parallelize independent verifications. If a source is unreachable, say so explicitly in the
+report — never silently downgrade "couldn't check" to "checked".
+
+## 4. Classify
+
+- **fresh** — every claim holds. Don't touch it.
+- **stale** — some claim is outdated (moved path, changed number, closed issue, implemented
+  gap). → **Correct the body now, with the measured value and the date.** Corrections are
+  within autonomous scope; they are additive truth, not deletion.
+- **dead** — the core premise is gone (library removed, feature retired, wholly superseded).
+  → Mark as an archive **candidate** only.
+
+## 5. Stale patterns worth hunting
+
+Beyond "the number changed", these recur and are easy to miss:
+
+- **Fixed-gap drift** — the memory documents a missing capability ("there is no startup
+  reconcile", "no rate limiting yet") and it has since been built. This is the most dangerous
+  class: the agent re-implements or re-reports work that already shipped. Check the linked
+  issue *and* grep for the symbol.
+- **Cross-memory contradiction** — two memories disagree (one says a script is the way to do
+  X, another says that script was retired). At least one is stale by definition. Compare
+  claims across files, not only file-by-file.
+- **Scale drift** — "table T has ~8M rows" written months ago now off by 25%. Harmless as
+  trivia, harmful when the memory derives advice from it (batch sizes, timeout budgets,
+  "this query takes 19s").
+- **Recipe rot** — the memory stores a command/query as a verified recipe, and the recipe no
+  longer works at today's data volume or API version. **Re-run stored recipes**; a recipe you
+  did not execute is unverified.
+- **Progress-state drift** — a long-running job/backfill memory whose "current status" section
+  is weeks behind, sometimes with two internally contradictory status sections stacked up.
+  Date each section, keep the newest, mark superseded ones.
+- **Identity mismatch** — `name`/`description` says one thing, the body says the opposite
+  (e.g. a file named `*-via-toolX` whose body records that toolX was abandoned). Recall
+  matches on description, so the file gets loaded for the wrong reason, or missed entirely.
+
+## 6. Report, then apply
+
+Report as a table before changing anything — file · class · one-line evidence · action:
+
+| File | Class | Evidence | Action |
+| --- | --- | --- | --- |
+| `reference_x.md` | stale | script moved `scripts/` → `data/` | path corrected |
+| `project_y.md` | stale | claims "#302 reconcile missing"; `JobRunHistoryReconciler` exists, #302 closed | rewritten as done |
+| `project_z.md` | dead candidate | feature from #N removed in #M | awaiting approval |
+
+Then:
+
+1. **Apply corrections** to stale bodies — measured value + date, keeping the original
+   observation where it still carries a lesson ("was 8M as of <date>, 9.9M as of <today>").
+2. **Archive dead candidates only after explicit user approval**: `git mv` into
+   `<memory>/archive/` and add `archived: <date> <reason>` to the frontmatter. Never `rm`.
+3. **Sync the index** — reflect corrections, drop archived entries from `MEMORY.md`.
+4. **Commit through the project's normal workflow** (issue → branch/worktree → PR/MR). Memory
+   is team-shared content; it does not get direct-to-main commits.
+
+## Judgment rules — stay conservative
+
+- **Unverifiable ⇒ fresh.** If the source of truth is unreachable, leave the memory alone and
+  say the check was skipped. Unknown is not dead.
+- **Incident lessons stay fresh even when the code moves.** A memory recording *why something
+  broke* exists to prevent recurrence, not to snapshot a call site. Correct its stale path
+  references; do not retire the lesson because the file was renamed.
+- **Report the drift, don't invent the cause.** If a count inverted or a number moved
+  inexplicably, record the measurement and flag it as unexplained. A plausible story written
+  into memory becomes tomorrow's false fact.
+- **Prefer merge over create.** Two memories on one topic → propose merging into the existing
+  one.
+- **Non-obvious facts discovered by the audit itself become new memories** — the audit is
+  itself a source of ground truth.
+
+## Field notes
+
+- Fresh timestamps prove nothing. A file committed this week can carry a claim that was
+  already false when written; a file untouched for months can be perfectly true. Verify
+  claims, never sort by date and trim the tail.
+- `count(*)` on a large table may exceed the DB tool's statement timeout — that failure *is*
+  a finding when the memory claims the query is fast.
+- Quote globs when shelling out from zsh (`grep --include="*.java"`), or the shell eats them
+  and the check silently returns nothing — a false "fresh".
+- An issue being closed does not by itself prove the described work shipped. For fixed-gap
+  claims, confirm with a grep for the symbol as well.

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -53,6 +53,7 @@ new_sandbox
 "$INSTALL" --skill-only >/dev/null 2>&1
 check "exit code" "0" "$?"
 check "Skill 설치" "$SRC" "$(readlink "$HOME/.agents/skills/mobile-web-planner" 2>/dev/null)"
+check "memory-factcheck 설치" "$REPO_ROOT/skills/memory-factcheck" "$(readlink "$HOME/.agents/skills/memory-factcheck" 2>/dev/null)"
 check "Claude Agent 미설치" "absent" "$([[ -e "$HOME/.claude/agents/mobile-web-planner.md" ]] && echo present || echo absent)"
 check "Codex Agent 미설치" "absent" "$([[ -e "$HOME/.codex/agents/mobile_web_planner.toml" ]] && echo present || echo absent)"
 drop_sandbox
@@ -77,7 +78,7 @@ new_sandbox
 "$INSTALL" >/dev/null 2>&1
 out="$("$INSTALL" 2>&1)"
 check "exit code" "0" "$?"
-check "skip 3건" "3" "$(grep -c '^skip' <<<"$out")"
+check "skip 6건" "6" "$(grep -c '^skip' <<<"$out")"
 drop_sandbox
 
 echo "test: 남의 디렉터리가 있으면 덮어쓰지 않고 실패한다"
@@ -154,6 +155,7 @@ new_sandbox
 check "exit code" "0" "$?"
 for t in ".agents/skills" ".claude/skills" ".gemini/config/skills"; do
   check "$t 제거" "absent" "$([[ -e "$HOME/$t/mobile-web-planner" ]] && echo present || echo absent)"
+  check "$t memory-factcheck 제거" "absent" "$([[ -e "$HOME/$t/memory-factcheck" ]] && echo present || echo absent)"
 done
 drop_sandbox
 


### PR DESCRIPTION
Closes #47

`leeyudok/memory-factcheck` 의 스킬을 이식하고(원 리포 커밋 491d7ee), `install.sh` 를 단일 SKILL_NAME 하드코딩에서 `skills/*/` 순회로 일반화한다. Agent Adapter 는 mobile-web-planner 전용으로 유지. README 에 스킬 목록 표를 추가하고 AGENTS.md 에 멀티 스킬 저장소 성격을 명시했다.

검증: 단위 테스트 73건 + install 테스트 51건(4건 추가) 통과. 머지 후 원 리포(GitHub·로컬 클론)는 삭제 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)