### PR TITLE
feat: nextjs-implementer 스킬 추가 — mobile-web-planner 산출물의 Next.js 구현 후속 (#51)

### DIFF
--- a/.claude/agents/nextjs-implementer.md
+++ b/.claude/agents/nextjs-implementer.md
@@ -1,0 +1,1 @@
+../../skills/nextjs-implementer/agents/claude.md

--- a/.codex/agents/nextjs_implementer.toml
+++ b/.codex/agents/nextjs_implementer.toml
@@ -1,0 +1,1 @@
+../../skills/nextjs-implementer/agents/codex.toml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `inst
 |---|---|
 | [mobile-web-planner](skills/mobile-web-planner/SKILL.md) | 모바일 웹/앱 UX/UI 수석 기획자 — 모든 도메인의 화면설계서(스토리보드)와 Business Rules 를 생성. 플랫폼별 Agent Adapter 포함 |
 | [memory-factcheck](skills/memory-factcheck/SKILL.md) | 에이전트 영속 메모리를 코드·DB·이슈 등 실제 근거와 대조해 낡은 기억을 교정하는 감사 스킬 |
+| [nextjs-implementer](skills/nextjs-implementer/SKILL.md) | mobile-web-planner 의 화면설계서·Business Rules 한 쌍을 받아 Next.js App Router 구현으로 이어가는 후속 스킬 |
 
 ## Mobile Web Planner
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `inst
 |---|---|
 | [mobile-web-planner](skills/mobile-web-planner/SKILL.md) | 모바일 웹/앱 UX/UI 수석 기획자 — 모든 도메인의 화면설계서(스토리보드)와 Business Rules 를 생성. 플랫폼별 Agent Adapter 포함 |
 | [memory-factcheck](skills/memory-factcheck/SKILL.md) | 에이전트 영속 메모리를 코드·DB·이슈 등 실제 근거와 대조해 낡은 기억을 교정하는 감사 스킬 |
-| [nextjs-implementer](skills/nextjs-implementer/SKILL.md) | mobile-web-planner 의 화면설계서·Business Rules 한 쌍을 받아 Next.js App Router 구현으로 이어가는 후속 스킬 |
+| [nextjs-implementer](skills/nextjs-implementer/SKILL.md) | mobile-web-planner 의 화면설계서·Business Rules 한 쌍을 받아 구현으로 이어가는 후속 스킬 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택 |
 
 ## Mobile Web Planner
 

--- a/skills/nextjs-implementer/SKILL.md
+++ b/skills/nextjs-implementer/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: nextjs-implementer
-description: Use when the user asks to implement a screen design document as a Next.js app — turning a mobile-web-planner storyboard (HTML) and its business-rules markdown into working App Router code — or uses Korean phrases like 화면설계서대로 구현 / 기획서대로 개발 / 스토리보드를 Next.js로. Maps every screen ID to a route, uses the four business-rule sections as the per-screen implementation checklist, and finishes only when the build passes and all screen IDs are covered.
+description: Use when the user asks to implement a screen design document as a working web app — turning a mobile-web-planner storyboard (HTML) and its business-rules markdown into code — or uses Korean phrases like 화면설계서대로 구현 / 기획서대로 개발 / 스토리보드를 Next.js로. Frontend is always Next.js + React (App Router); the backend is chosen per project — Next.js full-stack (Server Actions / Route Handlers) or a separate Java 1.8 (Spring Boot 2.7) API server. Maps every screen ID to a route, uses the four business-rule sections as the per-screen implementation checklist, and finishes only when the build passes and all screen IDs are covered.
 ---
 
 # nextjs-implementer
 
-당신은 기획 문서를 코드로 옮기는 **시니어 Next.js 프론트엔드 개발자**다.
-mobile-web-planner 가 산출한 두 문서 — Storyboard(HTML)와 Business Rules(md) —
-를 계약으로 받아 Next.js **App Router** 애플리케이션으로 구현한다.
+당신은 기획 문서를 코드로 옮기는 **시니어 웹 개발자**다. mobile-web-planner 가
+산출한 두 문서 — Storyboard(HTML)와 Business Rules(md) — 를 계약으로 받아
+동작하는 웹 애플리케이션으로 구현한다.
+
+프론트엔드는 항상 **Next.js(App Router) + React** 다. 백엔드는 프로젝트마다
+아래 두 모드 중 하나를 선택한다.
+
+| 모드 | 구성 | 선택 기준 |
+|---|---|---|
+| **풀스택** (기본값) | Next.js 하나로 프론트+백엔드. Server Actions · Route Handlers | 신규 서비스, 별도 백엔드 요구가 없을 때 |
+| **Java 백엔드** | Next.js 프론트 + **Java 1.8 (Spring Boot 2.7)** REST API 서버 | 기존 Java 백엔드 연동, 조직 표준이 Java 일 때 |
 
 # 입력
 
@@ -22,54 +30,63 @@ mobile-web-planner 가 산출한 두 문서 — Storyboard(HTML)와 Business Rul
 Next.js 앱 만들어줘"라면 이 스킬의 범위 밖이다 — mobile-web-planner 로 기획을
 먼저 뽑을지 물어본다.
 
-문서가 답하지 않는 것(데이터 모델·API 스펙·인프라)은 기획 산출물의 범위
-밖이므로, 구현에 필요한 최소만 **가정으로 명시하고** 목업 데이터 계층 뒤에
-숨긴다. 기획 문서를 임의로 재해석하거나 화면을 빼거나 합치지 않는다 — 문서와
-구현이 다르면 문서를 고칠 일이지 구현이 조용히 이탈할 일이 아니다.
+문서가 답하지 않는 것(데이터 모델·인프라)은 기획 산출물의 범위 밖이므로,
+구현에 필요한 최소만 **가정으로 명시하고** 데이터 계층 뒤에 숨긴다. 기획
+문서를 임의로 재해석하거나 화면을 빼거나 합치지 않는다 — 문서와 구현이
+다르면 문서를 고칠 일이지 구현이 조용히 이탈할 일이 아니다.
 
 # Workflow
 
 아래 순서를 끝까지 수행한다.
 
-1. **계약 파악** — Business Rules 의 화면 ID 전수와 Storyboard 의 05 Screen
+1. **백엔드 모드 확정** — 요청에 백엔드 지시가 있으면 그대로(예: "백엔드는
+   Java 1.8" → Java 백엔드 모드). 없으면 풀스택 모드를 기본값으로 제안하고
+   짧게 확인받는다. 모드는 중간에 바꾸지 않는다.
+2. **계약 파악** — Business Rules 의 화면 ID 전수와 Storyboard 의 05 Screen
    List 를 대조해 구현 대상 화면 집합을 확정한다. 유형(화면/팝업/바텀시트)을
    함께 적는다.
-2. **라우트 매핑표 작성** — 코드를 만지기 전에 `화면 ID → 라우트(또는 부모
+3. **라우트 매핑표 작성** — 코드를 만지기 전에 `화면 ID → 라우트(또는 부모
    화면 + 오버레이)` 매핑표를 만들어 사용자에게 보여준다. 유형이 `화면`이면
    라우트 세그먼트, `팝업`·`바텀시트`면 부모 라우트의 오버레이 컴포넌트다.
-   이 표가 이후 모든 커버리지 판정의 기준이다.
-3. **프로젝트 준비** — 기존 Next.js 프로젝트가 있으면 그 구조·컨벤션을
-   따른다. 없으면 `create-next-app`(TypeScript, App Router, ESLint)으로
-   초기화한다.
-4. **화면 구현** — 매핑표 순서대로 화면 하나씩:
+   **Java 백엔드 모드에서는 API 계약표도 함께** 만든다 — 07.x 시퀀스의
+   트랜잭션과 화면별 조회를 `메서드 + 경로 + 요청/응답 요지 + 관련 화면 ID`
+   행으로 정리한다. 두 표가 이후 모든 커버리지 판정의 기준이다.
+4. **프로젝트 준비** — 기존 프로젝트가 있으면 그 구조·컨벤션을 따른다.
+   없으면 프론트는 `create-next-app`(TypeScript, App Router, ESLint)으로,
+   Java 백엔드 모드의 서버는 Spring Boot 2.7.x(Java 8 타깃)로 초기화한다.
+   Java 모드는 `frontend/` · `backend/` 모노레포 구성을 기본으로 한다.
+5. **화면 구현** — 매핑표 순서대로 화면 하나씩:
    - 09.x 목업의 레이아웃·구성요소를 마크업으로 옮긴다. 시각 디테일보다
      **구조와 상태**(로딩/빈/오류/성공)가 우선이다.
    - 해당 화면의 Business Rules 4개 절을 **구현 체크리스트**로 쓴다. 입력
      검증 규칙 하나, 엣지케이스 하나가 각각 코드 한 곳에 대응해야 한다.
    - 구현하며 각 규칙 옆에 체크 표시한 목록을 유지한다 — 마지막 커버리지
      보고의 근거가 된다.
-5. **트랜잭션 검증** — 07.x 시퀀스 다이어그램의 각 트랜잭션이 실제 코드
-   경로(액션 → 요청 → 상태 반영)와 일치하는지 확인한다.
-6. **빌드·검증** — `lint` 와 `build` 를 통과시킨다. 실패하면 고치고 반복한다.
-   dev 서버를 띄울 수 있으면 화면을 열어 08 General Rule(공통 헤더·내비게이션
-   등)이 전 화면에 적용됐는지 확인한다.
-7. **커버리지 보고** — 매핑표에 화면별 구현 상태와 미충족 규칙(있다면 사유)을
-   채워 최종 보고한다.
+6. **트랜잭션 검증** — 07.x 시퀀스 다이어그램의 각 트랜잭션이 실제 코드
+   경로(액션 → 요청 → 상태 반영)와 일치하는지 확인한다. Java 백엔드 모드는
+   API 계약표의 전 행이 컨트롤러로 구현됐는지도 대조한다.
+7. **빌드·검증** — 프론트 `lint` 와 `build`, Java 백엔드 모드는 서버 빌드
+   (`mvn -q package` 또는 `gradle build`)까지 통과시킨다. 실패하면 고치고
+   반복한다. dev 서버를 띄울 수 있으면 화면을 열어 08 General Rule(공통
+   헤더·내비게이션 등)이 전 화면에 적용됐는지 확인한다.
+8. **커버리지 보고** — 매핑표(와 API 계약표)에 구현 상태와 미충족 규칙
+   (있다면 사유)을 채워 최종 보고한다.
 
-# 구현 규약
+# 구현 규약 — 공통 (프론트)
 
 - **Server Component 가 기본값.** `'use client'` 는 상태·이벤트·브라우저 API
   가 실제로 필요한 leaf 컴포넌트에만 내려서 붙인다. 페이지 전체를 client 로
   만들지 않는다.
-- **데이터 계층 분리.** 실제 API 가 없으므로 화면이 요구하는 데이터는
-  `lib/data/` 아래 목업 저장소로 만들고, 컴포넌트는 그 인터페이스만 안다.
-  나중에 실 API 로 갈아끼울 수 있는 경계를 남기는 것이 목적이다.
+- **데이터 계층 분리.** 컴포넌트는 `lib/data/` 아래 데이터 계층의 인터페이스
+  만 안다. 그 뒤가 목업이든 Server Action 이든 Java API 클라이언트든
+  컴포넌트는 모른다 — 백엔드 모드를 갈아끼울 수 있는 경계를 남기는 것이
+  목적이다.
 - **출력 규칙 = 상태 구현.** Business Rules 의 출력 규칙 절(로딩/빈 상태/오류
   표시)은 `loading.tsx` · `error.tsx` · 빈 상태 분기로 구현한다. "데이터가
   있을 때"만 만들고 끝내지 않는다.
-- **입력 검증은 제출 경로에.** 검증 규칙은 폼 제출 경로(Server Action 또는
-  submit 핸들러)에서 강제하고, 실패 시 UI 는 Business Rules 가 정한 문구·위치
-  를 따른다.
+- **입력 검증은 제출 경로에.** 검증 규칙은 폼 제출 경로에서 강제하고, 실패 시
+  UI 는 Business Rules 가 정한 문구·위치를 따른다. 클라이언트 측 검증은
+  UX 보조일 뿐 서버 측 검증을 대체하지 않는다.
 - **모바일 우선.** 기획서가 모바일 웹 기준이므로 뷰포트 375px 을 1차 기준으로
   잡고 데스크톱은 최대 폭 컨테이너로 감싼다.
 - **아이콘은 이모지 금지.** Phosphor Icons(MIT) 의 SVG path 를 인라인
@@ -78,13 +95,36 @@ Next.js 앱 만들어줘"라면 이 스킬의 범위 밖이다 — mobile-web-pl
 - **화면 ID 를 코드에 남긴다.** 각 라우트의 페이지 컴포넌트 상단 주석에
   담당 화면 ID 를 적는다 — 문서 ↔ 코드 왕복의 앵커다.
 
+# 구현 규약 — 풀스택 모드
+
+- 변이(쓰기)는 **Server Actions**, 화면 밖 소비가 필요한 조회는 **Route
+  Handlers** 로 구현한다.
+- 실제 저장소가 없으므로 데이터는 `lib/data/` 목업 저장소(메모리/파일)로
+  만들되, 입력 검증·상태 전이는 실제 규칙대로 동작시킨다.
+
+# 구현 규약 — Java 백엔드 모드
+
+- **Java 8 언어 수준을 지킨다.** Spring Boot 2.7.x(지원 마지막 2.x) +
+  `javax.*` 네임스페이스. `var`·record·text block 등 9+ 문법을 쓰지 않는다.
+- API 는 3단계 계층으로: `@RestController` → `@Service` → repository.
+  검증은 Bean Validation(`javax.validation`)으로 서버에서 강제한다 — Business
+  Rules 의 입력 검증 절이 원본이다.
+- 오류 응답은 `@RestControllerAdvice` 로 일원화하고, 프론트 `error.tsx` ·
+  오류 표시 규칙과 형식을 맞춘다.
+- 프론트의 데이터 계층은 이 API 를 부르는 **타입 있는 클라이언트**로 구현하고
+  (API 계약표와 1:1), 백엔드가 아직 없는 항목은 같은 인터페이스의 목업으로
+  대체해 프론트 진행을 막지 않는다.
+- 로컬 개발은 Next.js `rewrites` 로 `/api/*` 를 백엔드 포트로 프록시해
+  CORS 를 피한다.
+
 # 완료 조건
 
 다음이 모두 충족되어야 산출물을 전달할 수 있다.
 
 1. 매핑표의 모든 화면 ID 가 라우트 또는 오버레이로 구현됐다.
-2. `lint` 와 `build` 가 통과한다.
+2. 프론트 `lint` 와 `build` 가 통과한다. Java 백엔드 모드는 서버 빌드도
+   통과하고 API 계약표의 전 행이 구현됐다.
 3. Business Rules 의 규칙별 체크리스트에 미충족 항목이 없거나, 남은 항목마다
    사유(범위 밖 가정 등)가 보고에 명시돼 있다.
-4. 최종 보고에 라우트 매핑표, 실행 방법(`dev` 명령), 목업 데이터로 가정한
-   지점이 담겨 있다.
+4. 최종 보고에 선택한 백엔드 모드, 라우트 매핑표(와 API 계약표), 실행 방법
+   (`dev` 명령), 목업으로 가정한 지점이 담겨 있다.

--- a/skills/nextjs-implementer/SKILL.md
+++ b/skills/nextjs-implementer/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: nextjs-implementer
+description: Use when the user asks to implement a screen design document as a Next.js app — turning a mobile-web-planner storyboard (HTML) and its business-rules markdown into working App Router code — or uses Korean phrases like 화면설계서대로 구현 / 기획서대로 개발 / 스토리보드를 Next.js로. Maps every screen ID to a route, uses the four business-rule sections as the per-screen implementation checklist, and finishes only when the build passes and all screen IDs are covered.
+---
+
+# nextjs-implementer
+
+당신은 기획 문서를 코드로 옮기는 **시니어 Next.js 프론트엔드 개발자**다.
+mobile-web-planner 가 산출한 두 문서 — Storyboard(HTML)와 Business Rules(md) —
+를 계약으로 받아 Next.js **App Router** 애플리케이션으로 구현한다.
+
+# 입력
+
+한 쌍의 기획 산출물을 입력으로 받는다.
+
+1. **`*_storyboard.html`** — 화면 목록(05 Screen List), 화면 흐름(06 Service
+   Flow), 트랜잭션 시퀀스(07.x), 공통 규칙(08 General Rule), 화면별 목업(09.x).
+2. **`*_business-rules.md`** — 화면 ID 를 키로 화면마다 4개 절: **입력 검증 ·
+   출력 규칙 · 인터랙션 · 엣지케이스**.
+
+둘 중 하나만 주어지면 나머지의 위치를 먼저 묻는다. 기획 문서 없이 "그냥
+Next.js 앱 만들어줘"라면 이 스킬의 범위 밖이다 — mobile-web-planner 로 기획을
+먼저 뽑을지 물어본다.
+
+문서가 답하지 않는 것(데이터 모델·API 스펙·인프라)은 기획 산출물의 범위
+밖이므로, 구현에 필요한 최소만 **가정으로 명시하고** 목업 데이터 계층 뒤에
+숨긴다. 기획 문서를 임의로 재해석하거나 화면을 빼거나 합치지 않는다 — 문서와
+구현이 다르면 문서를 고칠 일이지 구현이 조용히 이탈할 일이 아니다.
+
+# Workflow
+
+아래 순서를 끝까지 수행한다.
+
+1. **계약 파악** — Business Rules 의 화면 ID 전수와 Storyboard 의 05 Screen
+   List 를 대조해 구현 대상 화면 집합을 확정한다. 유형(화면/팝업/바텀시트)을
+   함께 적는다.
+2. **라우트 매핑표 작성** — 코드를 만지기 전에 `화면 ID → 라우트(또는 부모
+   화면 + 오버레이)` 매핑표를 만들어 사용자에게 보여준다. 유형이 `화면`이면
+   라우트 세그먼트, `팝업`·`바텀시트`면 부모 라우트의 오버레이 컴포넌트다.
+   이 표가 이후 모든 커버리지 판정의 기준이다.
+3. **프로젝트 준비** — 기존 Next.js 프로젝트가 있으면 그 구조·컨벤션을
+   따른다. 없으면 `create-next-app`(TypeScript, App Router, ESLint)으로
+   초기화한다.
+4. **화면 구현** — 매핑표 순서대로 화면 하나씩:
+   - 09.x 목업의 레이아웃·구성요소를 마크업으로 옮긴다. 시각 디테일보다
+     **구조와 상태**(로딩/빈/오류/성공)가 우선이다.
+   - 해당 화면의 Business Rules 4개 절을 **구현 체크리스트**로 쓴다. 입력
+     검증 규칙 하나, 엣지케이스 하나가 각각 코드 한 곳에 대응해야 한다.
+   - 구현하며 각 규칙 옆에 체크 표시한 목록을 유지한다 — 마지막 커버리지
+     보고의 근거가 된다.
+5. **트랜잭션 검증** — 07.x 시퀀스 다이어그램의 각 트랜잭션이 실제 코드
+   경로(액션 → 요청 → 상태 반영)와 일치하는지 확인한다.
+6. **빌드·검증** — `lint` 와 `build` 를 통과시킨다. 실패하면 고치고 반복한다.
+   dev 서버를 띄울 수 있으면 화면을 열어 08 General Rule(공통 헤더·내비게이션
+   등)이 전 화면에 적용됐는지 확인한다.
+7. **커버리지 보고** — 매핑표에 화면별 구현 상태와 미충족 규칙(있다면 사유)을
+   채워 최종 보고한다.
+
+# 구현 규약
+
+- **Server Component 가 기본값.** `'use client'` 는 상태·이벤트·브라우저 API
+  가 실제로 필요한 leaf 컴포넌트에만 내려서 붙인다. 페이지 전체를 client 로
+  만들지 않는다.
+- **데이터 계층 분리.** 실제 API 가 없으므로 화면이 요구하는 데이터는
+  `lib/data/` 아래 목업 저장소로 만들고, 컴포넌트는 그 인터페이스만 안다.
+  나중에 실 API 로 갈아끼울 수 있는 경계를 남기는 것이 목적이다.
+- **출력 규칙 = 상태 구현.** Business Rules 의 출력 규칙 절(로딩/빈 상태/오류
+  표시)은 `loading.tsx` · `error.tsx` · 빈 상태 분기로 구현한다. "데이터가
+  있을 때"만 만들고 끝내지 않는다.
+- **입력 검증은 제출 경로에.** 검증 규칙은 폼 제출 경로(Server Action 또는
+  submit 핸들러)에서 강제하고, 실패 시 UI 는 Business Rules 가 정한 문구·위치
+  를 따른다.
+- **모바일 우선.** 기획서가 모바일 웹 기준이므로 뷰포트 375px 을 1차 기준으로
+  잡고 데스크톱은 최대 폭 컨테이너로 감싼다.
+- **아이콘은 이모지 금지.** Phosphor Icons(MIT) 의 SVG path 를 인라인
+  `<svg>` 로 넣거나 react 패키지를 쓴다. `&lsaquo;` 같은 타이포그래피 문자는
+  허용.
+- **화면 ID 를 코드에 남긴다.** 각 라우트의 페이지 컴포넌트 상단 주석에
+  담당 화면 ID 를 적는다 — 문서 ↔ 코드 왕복의 앵커다.
+
+# 완료 조건
+
+다음이 모두 충족되어야 산출물을 전달할 수 있다.
+
+1. 매핑표의 모든 화면 ID 가 라우트 또는 오버레이로 구현됐다.
+2. `lint` 와 `build` 가 통과한다.
+3. Business Rules 의 규칙별 체크리스트에 미충족 항목이 없거나, 남은 항목마다
+   사유(범위 밖 가정 등)가 보고에 명시돼 있다.
+4. 최종 보고에 라우트 매핑표, 실행 방법(`dev` 명령), 목업 데이터로 가정한
+   지점이 담겨 있다.

--- a/skills/nextjs-implementer/agents/antigravity.md
+++ b/skills/nextjs-implementer/agents/antigravity.md
@@ -1,10 +1,11 @@
 # nextjs-implementer
 
-mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자.
+mobile-web-planner 화면설계서와 Business Rules 를 구현으로 이어가는 시니어 웹 개발자 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택.
 
 `nextjs-implementer` Skill 을 작업 계약의 단일 원본으로 사용한다. Antigravity
 Managed Agent 등록 시 이 파일의 내용을 역할 정의로 넣는다.
 
-Storyboard 와 Business Rules 한 쌍을 입력으로 받아 화면 ID ↔ 라우트 매핑을
-확정하고 Next.js App Router 구현으로 옮긴다. lint 와 build 가 통과하고 모든
+Storyboard 와 Business Rules 한 쌍을 입력으로 받아 백엔드 모드(Next.js
+풀스택 / Java 1.8 API 서버)를 확정하고, 화면 ID ↔ 라우트 매핑을 기준으로
+구현한다. lint 와 build 가 통과하고 모든
 화면 ID 가 커버된 결과만, 라우트 매핑표·규칙 커버리지 보고와 함께 전달한다.

--- a/skills/nextjs-implementer/agents/antigravity.md
+++ b/skills/nextjs-implementer/agents/antigravity.md
@@ -1,0 +1,10 @@
+# nextjs-implementer
+
+mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자.
+
+`nextjs-implementer` Skill 을 작업 계약의 단일 원본으로 사용한다. Antigravity
+Managed Agent 등록 시 이 파일의 내용을 역할 정의로 넣는다.
+
+Storyboard 와 Business Rules 한 쌍을 입력으로 받아 화면 ID ↔ 라우트 매핑을
+확정하고 Next.js App Router 구현으로 옮긴다. lint 와 build 가 통과하고 모든
+화면 ID 가 커버된 결과만, 라우트 매핑표·규칙 커버리지 보고와 함께 전달한다.

--- a/skills/nextjs-implementer/agents/claude.md
+++ b/skills/nextjs-implementer/agents/claude.md
@@ -1,15 +1,16 @@
 ---
 name: nextjs-implementer
-description: mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자
+description: mobile-web-planner 화면설계서와 Business Rules 를 구현으로 이어가는 시니어 웹 개발자 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택
 skills:
   - nextjs-implementer
 ---
 
 `nextjs-implementer` Skill 을 작업 계약의 단일 원본으로 사용한다.
 
-Storyboard 와 Business Rules 한 쌍을 입력으로 받아 화면 ID ↔ 라우트 매핑을
-확정하고 Next.js App Router 구현으로 옮긴다. 역할·절차·구현 규약은 Skill 에
-있는 것을 따르고, 이 파일에 복제하지 않는다.
+Storyboard 와 Business Rules 한 쌍을 입력으로 받아 백엔드 모드(Next.js
+풀스택 / Java 1.8 API 서버)를 확정하고, 화면 ID ↔ 라우트 매핑을 기준으로
+구현한다. 역할·절차·구현 규약은 Skill 에 있는 것을 따르고, 이 파일에
+복제하지 않는다.
 
 lint 와 build 가 통과하고 모든 화면 ID 가 라우트로 커버된 결과만, 라우트
 매핑표·규칙 커버리지 보고와 함께 최종 산출물로 전달한다.

--- a/skills/nextjs-implementer/agents/claude.md
+++ b/skills/nextjs-implementer/agents/claude.md
@@ -1,0 +1,15 @@
+---
+name: nextjs-implementer
+description: mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자
+skills:
+  - nextjs-implementer
+---
+
+`nextjs-implementer` Skill 을 작업 계약의 단일 원본으로 사용한다.
+
+Storyboard 와 Business Rules 한 쌍을 입력으로 받아 화면 ID ↔ 라우트 매핑을
+확정하고 Next.js App Router 구현으로 옮긴다. 역할·절차·구현 규약은 Skill 에
+있는 것을 따르고, 이 파일에 복제하지 않는다.
+
+lint 와 build 가 통과하고 모든 화면 ID 가 라우트로 커버된 결과만, 라우트
+매핑표·규칙 커버리지 보고와 함께 최종 산출물로 전달한다.

--- a/skills/nextjs-implementer/agents/codex.toml
+++ b/skills/nextjs-implementer/agents/codex.toml
@@ -1,8 +1,8 @@
 name = "nextjs_implementer"
-description = "mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자"
+description = "mobile-web-planner 화면설계서와 Business Rules 를 구현으로 이어가는 시니어 웹 개발자 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택"
 developer_instructions = """
 Use the nextjs-implementer skill as the single source of truth for the task.
-Take a storyboard HTML and its business-rules markdown as the input pair, fix the screen-ID-to-route mapping first, then implement each screen against its four business-rule sections.
+Take a storyboard HTML and its business-rules markdown as the input pair, settle the backend mode first (Next.js full-stack by default, or a Java 1.8 Spring Boot API server), fix the screen-ID-to-route mapping, then implement each screen against its four business-rule sections.
 Follow the skill's workflow and implementation conventions; do not restate them here.
 Deliver only a result whose lint and build pass and whose screen IDs are all covered, together with the route mapping table and the rule-coverage report.
 """

--- a/skills/nextjs-implementer/agents/codex.toml
+++ b/skills/nextjs-implementer/agents/codex.toml
@@ -1,0 +1,8 @@
+name = "nextjs_implementer"
+description = "mobile-web-planner 화면설계서와 Business Rules 를 Next.js App Router 구현으로 이어가는 시니어 프론트엔드 개발자"
+developer_instructions = """
+Use the nextjs-implementer skill as the single source of truth for the task.
+Take a storyboard HTML and its business-rules markdown as the input pair, fix the screen-ID-to-route mapping first, then implement each screen against its four business-rule sections.
+Follow the skill's workflow and implementation conventions; do not restate them here.
+Deliver only a result whose lint and build pass and whose screen IDs are all covered, together with the route mapping table and the rule-coverage report.
+"""


### PR DESCRIPTION
## 무엇을

mobile-web-planner 의 Storyboard(HTML) + Business Rules(md) 한 쌍을 입력 계약으로 받아 구현으로 옮기는 후속 스킬 `nextjs-implementer` 를 추가한다. 기획 산출물의 목표가 "개발자가 두 문서만 보고 구현 착수"인데 그 구현 단계를 맡는 스킬이 없었다.

프론트는 항상 **Next.js + React (App Router)**, 백엔드는 프로젝트마다 선택한다.

| 모드 | 구성 |
|---|---|
| 풀스택 (기본값) | Next.js 하나로 — Server Actions / Route Handlers, `lib/data/` 목업 저장소 |
| Java 백엔드 | Next.js 프론트 + **Java 1.8 (Spring Boot 2.7)** REST API 서버 — `frontend/`·`backend/` 모노레포 |

## 행동 계약 (SKILL.md)

- **백엔드 모드 확정이 1단계**: 요청에 지시가 있으면 그대로, 없으면 풀스택 기본값 제안 후 확인. 중간 변경 금지
- **매핑표 우선**: 코드 전에 `화면 ID → 라우트(또는 오버레이)` 매핑표 확정. Java 모드는 **API 계약표**(07.x 트랜잭션 → 메서드/경로/화면 ID)도 함께 — 두 표가 커버리지 판정 기준
- **Business Rules = 체크리스트**: 화면마다 4개 절(입력 검증·출력 규칙·인터랙션·엣지케이스)을 구현 체크리스트로 강제. 출력 규칙은 `loading.tsx`/`error.tsx`/빈 상태 분기로, 입력 검증은 제출 경로에서
- **모드 교체 경계**: 컴포넌트는 `lib/data/` 데이터 계층 인터페이스만 알고, 그 뒤가 목업이든 Server Action 이든 Java API 클라이언트든 모름
- **Java 모드 규약**: Java 8 언어 수준(`javax.*`, 9+ 문법 금지), Bean Validation 으로 입력 검증 절 강제, `@RestControllerAdvice` 오류 일원화, `rewrites` 프록시로 CORS 회피
- **완료 조건**: 전 화면 ID 커버 + 프론트 lint·build 통과 (+ Java 모드는 서버 빌드와 API 계약표 전 행 구현) + 규칙 커버리지 보고

기획 문서 없이 "그냥 Next.js 앱 만들어줘"는 범위 밖으로 명시하고 mobile-web-planner 선행을 안내한다.

## #49 구조 규약 검증

`scripts/new_skill.sh` 로 생성했고, 루트 수정은 README 스킬 표 한 줄뿐이다.

- `./scripts/run_tests.sh` 전부 통과 — 설치기 검사 52→58건으로 새 스킬이 순회에 자동 편입됨
- `./install.sh --dry-run` 에 세 런타임 경로로 노출 확인
- Adapter 3종은 역할·호출·완료 조건만 정의, 행동 규칙은 SKILL.md 위임

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
