### PR TITLE
ci: 테스트 워크플로 추가 — PR 머지 게이트용 (#55)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+# PR 과 main push 에서 저장소 전체 테스트를 돌린다.
+# 실행 내용은 로컬과 동일한 ./scripts/run_tests.sh 하나다 —
+# 루트 규약(tests/) + 모든 스킬 tests/ + install.sh 동작 테스트.
+# 이 잡은 main 브랜치 보호의 required status check 로 등록돼 있어,
+# 실패하면 PR 머지가 잠긴다.
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run repo + skill + installer tests
+        run: ./scripts/run_tests.sh


### PR DESCRIPTION
## 무엇을

PR 과 main push 에서 `./scripts/run_tests.sh`(루트 규약 + 모든 스킬 테스트 + 설치기 테스트)를 실행하는 GitHub Actions 워크플로를 추가한다.

## 왜

main 브랜치 보호에 PR 경유 머지는 강제돼 있지만 required status check 는 CI 가 없어 비어 있었다. 테스트가 "로컬에서 돌리고 보고를 신뢰"하는 구조라 테스트를 빠뜨린 PR 이 그대로 머지될 수 있다 — #53 의 run_tests.sh exit 5 버그도 로컬 실행으로만 잡혔다.

## 이후

이 PR 이 머지되면 브랜치 보호의 required status check 에 `test` 잡을 등록한다 → 테스트 실패 시 Merge 버튼 잠김. 이 PR 자체가 새 워크플로의 첫 검사 대상이다.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
