### PR TITLE
chore: doksam-ui 규칙 원문 참조를 /rules.md raw 엔드포인트로 전환 (#59)

### DIFF
--- a/skills/doksam-ui/SKILL.md
+++ b/skills/doksam-ui/SKILL.md
@@ -18,7 +18,7 @@ description: Use when building or modifying UI for a doksam project, when the us
 | 원천 | 용도 |
 |---|---|
 | `https://ui.doksam.com/llms.txt` | 기계 판독 카탈로그 — 설치 가능한 전 항목과 install 명령, 의존성 |
-| `https://ui.doksam.com/rules` | 사용 규칙 markdown 원문 (프롬프트에 그대로 붙일 수 있는 형태) |
+| `https://ui.doksam.com/rules.md` | 사용 규칙 markdown 원문 (raw — `curl -s https://ui.doksam.com/rules.md` 로 바로 읽는다) |
 | `https://ui.doksam.com/components` · `/patterns` · `/templates` · `/profiles` | 라이브 데모 + 코드 스니펫 |
 
 이 문서의 다이제스트와 사이트 내용이 충돌하면 **사이트를 따르고**, 이 스킬
@@ -51,7 +51,7 @@ description: Use when building or modifying UI for a doksam project, when the us
 
 # 규칙 다이제스트
 
-원문은 `ui.doksam.com/rules`. 아래는 위반이 잦은 핵심만 추린 것이다.
+원문은 `ui.doksam.com/rules.md`. 아래는 위반이 잦은 핵심만 추린 것이다.
 
 ## 컬러 · 토큰
 
@@ -110,7 +110,7 @@ description: Use when building or modifying UI for a doksam project, when the us
 # 완료 조건 — 표준 준수 체크리스트
 
 산출물 전달 전에 전 항목을 확인하고 결과를 보고한다 (원문:
-`ui.doksam.com/rules` 의 체크리스트).
+`ui.doksam.com/rules.md` 의 체크리스트).
 
 - [ ] 브랜드 프로필 지정 (admin/service/data/docs/console 중 1)
 - [ ] 프로필의 radius·density 를 임의 재정의하지 않음

--- a/skills/doksam-ui/tests/test_contract.py
+++ b/skills/doksam-ui/tests/test_contract.py
@@ -76,10 +76,12 @@ class TestLiveEndpoints(unittest.TestCase):
             self.fail("/r/registry.json 이 유효한 JSON 이 아니다")
         self.assertTrue(data, "레지스트리 인덱스가 비어 있다")
 
-    def test_rules_page_exists(self):
-        body = fetch("/rules")
+    def test_rules_md_is_raw_markdown(self):
+        body = fetch("/rules.md")
         if body is None:
-            self.skipTest("ui.doksam.com/rules 접근 불가")
+            self.skipTest("ui.doksam.com/rules.md 접근 불가")
+        self.assertTrue(body.lstrip().startswith("#"),
+                        "raw markdown 이 아니라 HTML 로 보인다")
         # 다이제스트가 요약해 온 핵심 규칙 표식이 원문에 남아 있어야 한다.
         for marker in ("하드코딩", "shadcn", "Phosphor"):
             with self.subTest(marker=marker):


### PR DESCRIPTION
ui.doksam.com 이 `/rules.md` 를 raw markdown 으로 서빙하기 시작해(200, `text/markdown` 실측), doksam-ui 스킬의 규칙 원문 인용을 HTML 임베드였던 `/rules` 에서 `/rules.md` 로 전환한다. SKILL.md 세 곳 + 계약 테스트(raw markdown 여부 검증 추가) 갱신. `./scripts/run_tests.sh` 전부 통과.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)