### PR TITLE
feat(mobile-web-planner): 템플릿 v2 — 2줄 헤더·실기기 목업·리얼 상태바·Liquid Glass 필 푸터 (#67)

### DIFF
--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -170,7 +170,16 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 - **문서 길이를 이유로 화면을 생략하지 않는다.** "n장이면 충분하다" 는 판단 기준이 아니다 — 기준은 "이 문서만 보고 서비스 전체를 구현할 수 있는가" 다. 분량이 부담스러우면 사용자에게 화면 목록을 먼저 제시하고 범위를 좁힐지 물어볼 수는 있으나, 스스로 조용히 축소하지 않는다.
 - 범위를 도출했으면 작성 시작 전에 화면 목록을 한 줄 요약으로 알린다 (확인 대기는 불필요 — 결과를 크게 바꾸는 애매함이 있을 때만 질문 규칙을 따른다).
 
-**화면 내부(mock-body)는 뼈대만 최소한으로 만들지 않는다.** 각 화면의 목적과 기능 복잡도를 스스로 분석하여, 실제 상용 서비스에서 기대되는 컴포넌트(필터, 탭, 상태 라벨, 메타데이터, CTA 버튼 등)와 더미 데이터를 **최대한 밀도 있게** 꽉 채워 넣는다. 설명 배지(`pointer-badge`)는 아래 '터치 요소 전수 규칙'을 따른다 — 재량이 아니다.
+**화면 내부(mock-body)는 뼈대만 최소한으로 만들지 않는다.** 각 화면의 목적과 기능 복잡도를 스스로 분석하여, 실제 상용 서비스에서 기대되는 컴포넌트(필터, 탭, 상태 라벨, 메타데이터, CTA 버튼 등)와 더미 데이터를 **최대한 밀도 있게** 꽉 채워 넣는다.
+
+**목업 밀도 기준은 "Figma 시안급"이다.** 회색 상자 나열이 아니라 실제 앱 스크린샷처럼 읽혀야 한다. 아래를 기본으로 쓴다.
+
+- **상태바**: `<div class="mock-status"></div>` 하나 — 9:41·신호·배터리는 CSS 가 그린다.
+- **헤더 백 버튼**: 화면 헤더 좌측에 `&lsaquo;` 를 기본으로 둔다 (iOS 대응). 최상위 탭 화면도 예외가 아니다.
+- **카드**: `background:#fff; border-radius:16px; padding:16px; box-shadow:0 1px 4px rgba(2,32,71,0.05);` — 본문 배경은 `#f2f4f6`.
+- **아바타 칩**: 종목·사용자 등 엔티티 행 앞에 이니셜 원형 칩 — `width:30px; height:30px; border-radius:50%; background:<브랜드색>; color:#fff; display:inline-flex; align-items:center; justify-content:center; font-weight:800;`.
+- **스파크라인**: 추세 있는 수치 행에는 인라인 `<svg>` polyline 미니 차트를 넣는다 — `<svg width="56" height="20" viewBox="0 0 56 20"><polyline points="0,15 18,16 36,11 56,7" fill="none" stroke="#f04452" stroke-width="1.6"/></svg>`.
+- **수치 강조**: 금액은 큰 굵은 타이포(letter-spacing -0.02em), 등락·상태는 연한 배경 칩(`background:#fdeef0; border-radius:6px; padding:3px 8px;`)으로. 설명 배지(`pointer-badge`)는 아래 '터치 요소 전수 규칙'을 따른다 — 재량이 아니다.
 
 **`09.x` 순서는 사용자가 기능을 나열한 순서를 따른다.** 중요도나 자기 판단으로 재배열하지 않는다 — 같은 요청에 항상 같은 순서가 나와야 사용자가 자기가 적은 순서대로 나왔는지 바로 확인할 수 있고, 문서를 다시 생성해도 순서가 흔들리지 않는다.
 
@@ -178,13 +187,17 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 - 나열 순서가 정보구조상 부자연스러워도 순서를 바꾸지 않는다. 대신 `04 IA` 다이어그램의 노드 배열을 `09.x` 순서에 맞춘다.
 - `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `05 Screen List` 의 행 순서, `09.x` 슬라이드 순서 **네 곳이 모두 같아야 한다.** (`06 Service Flow` 는 이동 그래프라 순서 제약이 없다.)
 
-**`09.x` 슬라이드 상단은 2행 헤더 표다.** `ppt-top-bar` 아래에 `ppt-head-bar`(1행), 그 아래에 `ppt-meta-bar`(2행)를 차례로 둔다 — 실무 화면설계서의 헤더 표를 재현한 구조다. 화면 상세(`09.x`) 외 슬라이드에는 두 줄 다 넣지 않는다 — 화면이 아니므로 화면 메타가 없다.
+**`09.x` 슬라이드 상단은 2행 헤더다 — 각 24px, 별도 행을 늘리지 않는다.**
 
-- **`ppt-head-bar`** 에는 `ppt-head-label`/`ppt-head-value` 쌍으로 **화면 Type · 요구사항 ID · 작업자** 세 칸을 적는다.
+- **1행 = `ppt-top-bar`**: `ppt-top-no`(NO.) · `ppt-top-title`(화면명) 다음에 `ppt-head-label`/`ppt-head-value` 쌍으로 **화면 Type · 요구사항 ID** 두 칸을 같은 줄에 잇는다. 우측 끝 Page 박스는 CSS 가 자동으로 붙인다.
   - 화면 Type 값은 `APP` `MOBILE WEB` `WEB` 중 하나다. 이 스킬의 기본 산출물은 `MOBILE WEB`.
   - 요구사항 ID 는 요청에 주어졌을 때만 적고, 없으면 `-` 로 둔다. 지어내지 않는다.
+  - `ppt-head-bar` 로 **행을 따로 만들지 않는다** — 구버전 호환용 클래스다.
+- **2행 = `ppt-meta-bar`**: `화면 ID` 라벨 + `ppt-meta-id`(좌측), `Location` 라벨 + `ppt-meta-value`, 끝에 `작업자` 라벨 + 값. 작업자 라벨에 인라인 `margin-left:auto` 를 줘 우측에 붙인다.
+  - Location 은 진입점부터 그 화면까지의 경로를 `>` 로 잇는다 — 예: `홈 > 게시판 > 글 상세`. `04 IA` 의 연결 관계에서 그대로 끌어온다.
   - 작업자 칸에는 **역할명**(예: `UX 기획`)을 적는다 — 산출물에 개인 이름을 넣지 않는 규칙은 여기에도 적용된다.
-- **`ppt-meta-bar`** 에는 화면 위치를 적는다. 진입점부터 그 화면까지의 경로를 `>` 로 잇는다 — 예: `홈 > 게시판 > 글 상세`. `04 IA` 의 연결 관계에서 그대로 끌어온다. 이 줄이 있으면 IA 슬라이드를 넘겨보지 않아도 화면이 앱 어디에 있는지 알 수 있다.
+
+화면 상세(`09.x`) 외 슬라이드에는 `ppt-meta-bar` 와 헤더 칸을 넣지 않는다 — 화면이 아니므로 화면 메타가 없다.
 
 **화면마다 화면 ID 를 부여하고 이동을 그 ID 로 가리킨다.** 슬라이드 번호(`09.2`)는 화면이 추가되면 밀리므로 참조가 어긋나고, 팝업처럼 슬라이드가 없는 대상은 가리킬 수도 없다.
 
@@ -240,7 +253,7 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 
 **해당하지 않으면 1개로 둔다.** 단순 조회·나열 화면(예: 회원 목록, 설정 메뉴)에 억지로 2개를 넣지 않는다 — 비교할 변형이 없으면 두 번째 목업은 같은 화면의 중복일 뿐이다.
 
-- **개수는 최대 4개.** 템플릿이 개수를 감지해 축소율을 조절한다(1개: 그대로, 2~3개: 90%, 4개: 68%). 5개 이상은 잘리므로 슬라이드를 나눈다.
+- **개수는 최대 4개.** 템플릿이 개수를 감지해 축소율을 조절한다(1개: 90%, 2~3개: 90%, 4개: 77%). 5개 이상은 잘리므로 슬라이드를 나눈다.
 - **각 목업에 `mock-caption` 으로 라벨을 붙인다** — `mock` 의 마지막 자식으로 두면 프레임 바로 위 남색 타이틀 바로 표시된다. 무엇의 변형인지 알 수 없으면 비교 슬라이드의 의미가 없다. (캡션은 단일 목업에도 필수다 — 위 공통 규칙.)
 - **`pointer-badge` 번호는 2단이다** — `<목업번호>-<요소번호>`. 첫 목업의 요소는 `1-1` `1-2`, 두 번째 목업은 `2-1` `2-2` 로 매긴다. 목업이 몇 번째인지가 번호에서 바로 읽히므로 "어느 목업의 항목인지" 를 따로 적을 필요가 없다.
 - **`desc-num` 도 같은 2단 표기를 쓴다** — 배지가 `1-1` 이면 설명도 `1-1`.
@@ -279,13 +292,13 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 | `ppt-top-no` | 상단 바 좌측 회색 번호 블록 (`NO. 01`) |
 | `ppt-top-title` | 상단 바 제목 |
 | `ppt-top-proj` | 상단 바 우측 프로젝트명 |
-| `ppt-head-bar` | 2행 헤더 표의 1행 (화면 Type · 요구사항 ID · 작업자). **화면 상세(`09.x`)에만** 둔다 |
-| `ppt-head-label` | 헤더 줄의 회색 라벨 칸 (`화면 Type`) |
-| `ppt-head-value` | 헤더 줄의 값 칸. 넘치면 말줄임 |
-| `ppt-meta-bar` | 2행 헤더 표의 2행 (Location · 화면 ID). **화면 상세(`09.x`)에만** 둔다 |
+| `ppt-head-label` | 헤더 칸 회색 라벨 (`화면 Type` `요구사항 ID`). **`ppt-top-bar` 안에** 둔다 |
+| `ppt-head-value` | 헤더 칸 값. 넘치면 말줄임 |
+| `ppt-head-bar` | (구버전 호환) 별도 헤더 행 — **새 문서에서 쓰지 않는다** |
+| `ppt-meta-bar` | 2행 헤더의 2행 (화면 ID · Location · 작업자). **화면 상세(`09.x`)에만** 둔다 |
 | `ppt-meta-label` | 메타 줄의 회색 라벨 칸 (`Location`) |
 | `ppt-meta-value` | 메타 줄의 값 칸. 넘치면 말줄임 |
-| `ppt-meta-id` | 메타 줄 우측 화면 ID 칸 |
+| `ppt-meta-id` | 화면 ID 칸. `화면 ID` 라벨(`ppt-meta-label`) 바로 뒤, 메타 줄 **좌측**에 둔다 |
 | `ppt-content` | 중간 영역 컨테이너 |
 | `ppt-body-full` | 좌우 분할하지 않는 통짜 콘텐츠 — 화면 상세(09.x)를 제외한 모든 슬라이드 |
 | `ppt-wireframe` | 좌측 와이어프레임 패널 (09.x). **`mock` 을 1개 이상(최대 4개) 배치할 수 있다** — 개수에 따라 축소율과 간격을 템플릿이 자동 조절한다 |
@@ -295,15 +308,16 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 | `desc-list` | 설명 리스트 (`ul`) |
 | `desc-num` | 설명 항목 번호. `pointer-badge` 와 같은 accent 칩으로 렌더되며 표기도 배지와 동일 (`1` 또는 `1-1`). 원문자(①②③) 금지 |
 | `pointer-badge` | 목업 위 accent 컬러 번호 배지. `desc-num` 과 1:1 대응. **`left:2px`** 로 둘 것 — `mock-body` 좌측 여백(1개 28px · 2개 이상 34px)이 배지 자리다. 폭은 내용에 맞춰 늘어난다. 음수 `left` 는 `mock-body`·`mock-screen` 의 overflow 에 절반이 잘린다 |
-| `mock` | 모바일 목업 외곽 프레임. `ppt-wireframe` 안에 여러 개 둘 수 있다 |
+| `mock` | 모바일 목업 외곽 프레임 320×694 (2.17:1 — 아이폰 17·갤럭시 S26 비율). 라운드·섀도는 템플릿이 처리, 인라인으로 덮지 않는다 |
 | `mock-caption` | 목업 상단 남색 타이틀 바. `mock` 의 마지막 자식으로 두면 프레임 위에 표시된다. **모든 목업에 필수** — `화면명 (화면 ID)` 형식으로 그 목업의 화면 ID 를 적고, 변형 케이스면 `화면명_변형명 (화면 ID)`. 예: `필터 선택됨 (DTC-FILTER-002)` |
 | `mock-partial` | 부분 목업(팝업·바텀시트). `mock` 과 **함께** 쓴다 — `class="mock mock-partial"` |
 | `mock-screen` | 목업 화면 |
-| `mock-status` | 목업 상태바 |
+| `mock-status` | 목업 상태바 — 빈 `<div>` 하나면 9:41·신호·배터리 글리프까지 CSS 가 렌더한다. 내용물을 넣지 않는다 |
 | `mock-header` | 목업 헤더 |
 | `mock-body` | 목업 본문 |
-| `mock-footer` | 목업 하단 탭 바 |
-| `mock-tab` | 하단 탭 항목. 활성 탭에 `active` 추가 |
+| `mock-footer` | 목업 하단 탭 바 (클래식 풀폭형) |
+| `mock-footer-pill` | **Liquid Glass 플로팅 필 탭 바 (iOS 26)** — `mock-footer` 대신 같은 자리(`mock-body` 다음 형제)에 둔다. 탭 바 있는 화면의 **기본 선택지**. 내부는 인라인 아이콘 svg, 활성 탭은 유리 버블(아래 마크업 예시) |
+| `mock-tab` | 하단 탭 항목 (`mock-footer` 용). 활성 탭에 `active` 추가 |
 | `ppt-footer` | 하단 남색 푸터 바 (28px). 좌측 "화면설계서" 라벨은 CSS 자동 — 마크업에는 우측 텍스트(`프로젝트명 | Ver.x`)만 넣는다 |
 | `<code>` (클래스 아님 · 엘리먼트) | 디자인 시스템 컴포넌트명 인라인 표기 |
 | `icon` | Phosphor 인라인 SVG 아이콘 |
@@ -319,7 +333,7 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 4. **배지 개수·표기** — 슬라이드마다 `pointer-badge` 개수와 `desc-num` 개수가 같은가. 다르면 모자란 쪽을 채워 1:1 로 맞춘다. `desc-num` 에 원문자(①②③)가 있으면 배지와 같은 평문 표기(`1`, `1-1`)로 바꾼다.
 5. **화면 순서** — `03 Index` 표의 행 순서, `04 IA` 의 노드 순서, `05 Screen List` 의 행 순서, `09.x` 슬라이드 순서 네 곳이 같은가. 그리고 그 순서가 사용자가 기능을 나열한 순서와 같은가(진입 화면은 `09.1`). 다르면 사용자 나열 순서를 기준으로 네 곳을 함께 맞춘다.
 6. **목업 개수** — `09.x` 마다 목업 트리거 표(위 `## 목업 여러 개 배치`)를 대조한다. 트리거에 해당하는데 `mock` 이 1개면 2개로 늘린다. 해당하지 않는데 2개면 1개로 줄인다. 그리고 목업 수와 `mock-caption` 수가 슬라이드마다 같은가 — 단일 목업에도 캡션이 있어야 한다.
-7. **화면 위치·헤더 표** — `09.x` 마다 `ppt-head-bar`(화면 Type · 요구사항 ID · 작업자)와 `ppt-meta-bar` 가 있고, Location 값이 `04 IA` 의 경로와 맞는가. 작업자 칸이 역할명인가(개인 이름 금지). 화면 상세 외 슬라이드에는 두 줄 다 없어야 한다.
+7. **화면 위치·헤더** — `09.x` 마다 1행(`ppt-top-bar` 안 화면 Type·요구사항 ID 칸)과 2행(`ppt-meta-bar`: 화면 ID·Location·작업자)이 있고, Location 값이 `04 IA` 의 경로와 맞는가. 작업자 칸이 역할명인가(개인 이름 금지). `ppt-head-bar` 를 새로 만들지 않았는가. 화면 상세 외 슬라이드에는 화면 메타가 없어야 한다.
 8. **화면 ID** — `09.x` 마다 `ppt-meta-id` 가 있는가. 각 `mock-caption` 에 그 목업의 ID 가 적혀 있는가. 본문에서 참조한 ID 를 모아 `ppt-meta-id` 와 `mock-caption` 에 정의된 ID 집합과 대조한다 — 어느 쪽에도 없는 ID 가 하나라도 있으면 그 화면을 추가하거나 참조를 고친다.
 9. **Business Rules** — Storyboard 에 정의한 화면 ID 집합과 Business Rules 문서의 `##` 섹션 ID 집합이 정확히 같은가. 각 섹션에 `### 입력 검증` `### 출력 규칙` `### 인터랙션` `### 엣지케이스` 네 헤딩이 모두 있고 내용이 비어 있지 않은가(해당 없으면 `해당 없음 — <이유>`). Rules 본문에서 참조한 화면 ID 가 전부 Storyboard 에 정의돼 있는가.
 10. **커버리지** — 기능 나열 없는 요청이라면: 같은 도메인의 상용 서비스에 있는 필수 플로우(온보딩/인증 · 프로필 · 내역 관리 · 알림 · 설정 · 신고/차단) 중 이 문서에 없는 것이 있는가. 있으면 화면을 추가하거나, 뺀 이유를 가정으로 명시했는지 확인한다. 나열 요청이어도 회원 전용 동작이 있으면 인증·온보딩·내 정보 화면이 있는가(없으면 제외 가정을 명시했는가).
@@ -459,22 +473,20 @@ Version: {{VERSION}}
   <div class="ppt-top-bar">
     <div class="ppt-top-no">NO. 09.1</div>
     <div class="ppt-top-title">Main Home</div>
-    <div class="ppt-top-proj">{{PROJECT_NAME}}</div>
-  </div>
-
-  <div class="ppt-head-bar">
     <div class="ppt-head-label">화면 Type</div>
     <div class="ppt-head-value">MOBILE WEB</div>
     <div class="ppt-head-label">요구사항 ID</div>
     <div class="ppt-head-value">-</div>
-    <div class="ppt-head-label">작업자</div>
-    <div class="ppt-head-value">UX 기획</div>
+    <!-- Page 박스는 CSS 가 자동으로 붙는다. ppt-top-proj 는 두지 않는다(푸터와 중복) -->
   </div>
 
   <div class="ppt-meta-bar">
+    <div class="ppt-meta-label">화면 ID</div>
+    <div class="ppt-meta-id">DTC-MAIN-001</div>
     <div class="ppt-meta-label">Location</div>
     <div class="ppt-meta-value">홈</div>
-    <div class="ppt-meta-id">DTC-MAIN-001</div>
+    <div class="ppt-meta-label" style="margin-left:auto;">작업자</div>
+    <div class="ppt-meta-value">UX 기획</div>
   </div>
 
   <div class="ppt-content">
@@ -482,18 +494,20 @@ Version: {{VERSION}}
     <div class="ppt-wireframe">
       <div class="mock">
         <div class="mock-screen">
-          <div class="mock-status"></div>
-          <div class="mock-header">헤더영역</div>
-          <div class="mock-body" style="position:relative;">
+          <div class="mock-status"></div> <!-- 빈 div 하나 — 9:41·배터리는 CSS 가 그린다 -->
+          <div class="mock-header"><span><span style="font-size:20px; font-weight:400; margin-right:8px;">&lsaquo;</span>메인 홈</span></div>
+          <div class="mock-body" style="position:relative; background:#f2f4f6;">
             <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
-            <!-- 목업 내용. 세부 스타일은 인라인 style 로 -->
+            <!-- 목업 내용. 세부 스타일은 인라인 style 로. 카드는 아래 "목업 밀도" 스니펫 참조 -->
           </div>
-          <div class="mock-footer" style="position:relative;">
-            <!-- mock-footer 처럼 mock-body 밖의 요소를 설명할 때는
-                 그 요소에 position:relative 를 주고 배지를 얹는다 -->
-            <span class="pointer-badge" style="position:absolute; top:9px; left:2px; z-index:10;">4</span>
-            <div class="mock-tab active">Home</div>
-            <div class="mock-tab">Search</div>
+          <div class="mock-footer-pill">
+            <!-- 탭 바 있는 화면의 기본형. 배지는 여기(position:relative)에 얹는다 -->
+            <span class="pointer-badge" style="position:absolute; top:10px; left:2px; z-index:10;">4</span>
+            <div style="display:flex; align-items:center; gap:6px; background:rgba(255,255,255,0.22); border:1px solid rgba(255,255,255,0.3); border-radius:17px; padding:6px 11px; box-shadow:inset 0 1px 2px rgba(255,255,255,0.35), 0 2px 8px rgba(0,0,0,0.25);">
+              <svg class="icon" viewBox="0 0 256 256" style="fill:#fff; width:14px; height:14px;"><path d="M218.83,103.77l-80-75.48a1.14,1.14,0,0,1-.11-.11,16,16,0,0,0-21.53,0l-.11.11L37.17,103.77A16,16,0,0,0,32,115.55V208a16,16,0,0,0,16,16H96a16,16,0,0,0,16-16V160h32v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V115.55A16,16,0,0,0,218.83,103.77ZM208,208H160V160a16,16,0,0,0-16-16H112a16,16,0,0,0-16,16v48H48V115.55l.11-.1L128,40l79.9,75.43.11.1Z"/></svg>
+              <span style="font-size:11px; font-weight:800; color:#fff;">홈</span>
+            </div>
+            <svg class="icon" viewBox="0 0 256 256" style="fill:rgba(255,255,255,0.75); width:14px; height:14px;"><path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"/></svg>
           </div>
         </div>
         <div class="mock-caption">메인 홈 (DTC-MAIN-001)</div>

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -70,7 +70,7 @@ body {
 
 /* Top Bar */
 .ppt-top-bar {
-  height: 48px;
+  height: 24px;
   background: #ffffff;
   display: flex;
   align-items: center;
@@ -82,15 +82,21 @@ body {
   height: 100%;
   display: flex;
   align-items: center;
-  padding: 0 24px;
+  padding: 0 14px;
   font-weight: 800;
-  font-size: 18px;
+  font-size: 12px;
+  flex: none;
 }
 .ppt-top-title {
-  padding: 0 24px;
-  color: #555555;
-  font-size: 18px;
-  font-weight: 500;
+  padding: 0 14px;
+  color: #333333;
+  font-size: 13px;
+  font-weight: 700;
+  flex: 1;              /* 우측 헤더 칸(화면 Type 등)을 오른쪽 끝으로 민다 */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .ppt-top-proj {
   margin-left: auto;
@@ -107,18 +113,18 @@ body {
   align-self: stretch;
   display: flex;
   align-items: center;
-  padding: 0 20px;
-  font-size: 13px;
+  padding: 0 14px;
+  font-size: 11px;
   font-weight: 700;
   flex: none;
 }
 
-/* 헤더 바 — 화면 상세(09.x) 슬라이드의 상단 바 아래 첫 줄.
-   실무 화면설계서 헤더 표의 1행(화면 Type · 요구사항 ID · 작업자)에
-   해당한다. 바로 아래 ppt-meta-bar(Location · 화면 ID)와 함께 2행
-   헤더 표를 이룬다. 칸 구성은 ppt-meta-bar 와 같은 라벨/값 반복이다. */
+/* (구버전 호환) 별도 헤더 행 — v2 부터는 화면 Type·요구사항 ID 칸을
+   ppt-top-bar 안에 직접 두므로 이 행을 새로 만들지 않는다. 기존 산출물
+   렌더 유지를 위해 정의만 남긴다. ppt-head-label/value 는 v2 에서
+   ppt-top-bar 의 칸으로 계속 쓰인다. */
 .ppt-head-bar {
-  height: 28px;
+  height: 24px;
   background: #f4f4f5;
   border-bottom: 1px solid #ccc;
   display: flex;
@@ -150,7 +156,7 @@ body {
    ppt-head-bar 와 합쳐 높이 56px 만큼 ppt-content 가 줄지만,
    목업(zoom 0.9 기준 540px)은 남는 높이 안에 그대로 들어간다. */
 .ppt-meta-bar {
-  height: 28px;
+  height: 24px;
   background: #f4f4f5;
   border-bottom: 1px solid #ccc;
   display: flex;
@@ -175,12 +181,14 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* 메타 줄의 마지막 칸(화면 ID)을 우측으로 민다. */
+/* 화면 ID 칸 — v2 2줄 헤더에서는 "화면 ID" 라벨 바로 뒤(좌측)에 놓인다.
+   우측 정렬이 필요한 구버전 산출물은 마크업 순서(마지막 칸)만으로도
+   어색하지 않게 flex 흐름을 따른다. */
 .ppt-meta-id {
-  margin-left: auto;
   padding: 0 12px;
   font-family: 'SFMono-Regular', Consolas, monospace;
-  font-size: 11px;
+  font-size: 12px;
+  font-weight: 700;
   color: #3f3f46;
   letter-spacing: 0.02em;
   flex: none;
@@ -190,14 +198,14 @@ body {
    경쟁해 시선을 뺏는다 (이슈 #65). 남색 #1e2a5c 는 mock-caption 과 같은
    고정 프레임색. 좌측 라벨은 CSS content 라 마크업 무변경. */
 .ppt-footer {
-  height: 28px;
+  height: 24px;
   background: #1e2a5c;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 16px;
+  padding: 0 14px;
   color: #ffffff;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   position: absolute;
   bottom: 0;
@@ -217,7 +225,7 @@ body {
   display: flex;
   gap: 12px;
   padding: 12px;
-  margin-bottom: 28px; /* Space for footer */
+  margin-bottom: 24px; /* Space for footer */
 }
 
 /* Cover & General Text Content (for non-wireframe slides) */
@@ -266,7 +274,7 @@ body {
 
 /* Right Description Panel */
 .ppt-desc-panel {
-  width: 380px;
+  width: 300px;
   background: #ffffff;
   border: 1px solid #aaa;
   display: flex;
@@ -353,13 +361,17 @@ body {
 }
 
 /* Mobile Mockup UI (Centered in Wireframe Panel) */
+/* 실기기 비율 320x694 = 2.17:1 (아이폰 17 402x874pt · 갤럭시 S26 384x832dp).
+   라운드 프레임과 섀도는 목업이 "디바이스"로 읽히게 하는 고정 프레임이다.
+   overflow 는 mock-screen 이 담당한다 — 여기 주면 상단 캡션 바가 잘린다. */
 .mock {
   width: 320px;
-  height: 600px;
-  border: 2px solid #555;
+  height: 694px;
+  border: 1px solid #d9dee4;
+  border-radius: 22px;
   background: #fff;
   padding: 0;
-  box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+  box-shadow: 0 12px 32px rgba(2,32,71,0.12);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -371,8 +383,30 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border-radius: 21px; /* .mock 라운드(22px) - border 1px */
 }
-.mock-status { height: 20px; background: #e2e8f0; }
+/* 리얼 상태바 — 9:41 + 신호/배터리 글리프를 CSS 만으로 렌더한다.
+   기존 산출물의 <div class="mock-status"></div> 가 그대로 업그레이드된다. */
+.mock-status {
+  height: 26px;
+  background: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 18px;
+  flex: none;
+}
+.mock-status::before {
+  content: "9:41";
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: #111111;
+}
+.mock-status::after {
+  content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="38" height="10" viewBox="0 0 38 10"><g fill="%23111"><rect x="0" y="6" width="2.5" height="4" rx="0.6"/><rect x="3.7" y="4" width="2.5" height="6" rx="0.6"/><rect x="7.4" y="2" width="2.5" height="8" rx="0.6"/><rect x="11.1" y="0" width="2.5" height="10" rx="0.6"/></g><rect x="18.5" y="0.5" width="15" height="9" rx="2.5" fill="none" stroke="%23111"/><rect x="20" y="2" width="11" height="6" rx="1.2" fill="%23111"/><rect x="34.5" y="3" width="2" height="4" rx="1" fill="%23111"/></svg>');
+  line-height: 0;
+}
 .mock-header {
   background: #fff;
   color: #111;
@@ -405,6 +439,27 @@ body {
 .mock-tab { font-size: 10px; color: #94a3b8; text-align: center; text-transform: uppercase; font-weight: 700;}
 .mock-tab.active { color: var(--accent); }
 
+/* Liquid Glass 플로팅 필 탭 바 (iOS 26) — mock-footer 와 같은 자리
+   (mock-body 의 다음 형제)에 두면 margin 으로 떠 있는 알약이 된다.
+   내부는 인라인 아이콘 svg + 활성 버블(인라인 style) 로 채운다.
+   44px 높이는 320px 폭 대비 실기기 비율(약 14%)에 맞춘 값. */
+.mock-footer-pill {
+  position: relative;
+  margin: 0 20px 10px;
+  height: 44px;
+  flex: none;
+  border-radius: 22px;
+  background: rgba(25,28,38,0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255,255,255,0.18);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.22);
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 0 6px;
+}
+
 /* 목업 2개 이상 배치 (상태 변화 · 단계 흐름 비교)
 
    아래 규칙은 전부 :has(.mock ~ .mock) 로 게이트되어 있다 — 형제 목업이
@@ -419,15 +474,15 @@ body {
    mock-body 의 배지 gutter(padding-left:28px)와 배지(left:2px + width:24px)가
    함께 줄어 2+24 <= 28 관계가 배율과 무관하게 보존된다 (이슈 #6 참조).
 
-   가용 폭 980px = 슬라이드 1400 - 테두리 2 - ppt-content padding 24
-                   - desc panel 380 - gap 12 - wireframe 테두리 2
-   가용 높이 627.5px = 787.5(16:9) - 테두리 2 - top bar 48 - head bar 28
-                       - meta bar 28 - footer 28 - ppt-content padding 24
-                       - wireframe 테두리 2
+   가용 폭 1060px = 슬라이드 1400 - 테두리 2 - ppt-content padding 24
+                    - desc panel 300 - gap 12 - wireframe 테두리 2
+   가용 높이 687.5px = 787.5(16:9) - 테두리 2 - top bar 24 - meta bar 24
+                       - footer 24 - ppt-content padding 24 - wireframe 테두리 2
                        (box-sizing:border-box 이므로 각 테두리는 height 에 포함)
-                       단일 목업 레이아웃 박스 600px 도 이 안에 들어간다.
-   2~3개: 320*0.9 = 288    -> 3*288 + 2*24(gap)   = 912   <= 980
-   4개  : 320*0.68 = 217.6 -> 4*217.6 + 3*24(gap) = 942.4 <= 980
+                       단일 목업: scale(0.9) 시 캡션 상단 여유 실측 약 1px — 계산 근거는
+                       694 박스가 687.5 안에서 -3.25px 오프셋, 시각 상단 31.4px.
+   2~3개: 320*0.9 = 288    -> 3*288 + 2*24(gap)   = 912    <= 1060
+   4개  : 320*0.77 = 246.4 -> 4*246.4 + 3*24(gap) = 1057.6 <= 1060
    5개 이상은 슬라이드를 나눈다. */
 .ppt-wireframe:has(.mock ~ .mock) { gap: 24px; }
 .ppt-wireframe:has(.mock ~ .mock) .mock {
@@ -435,7 +490,7 @@ body {
   transform: none; /* 아래 zoom 과 곱해지지 않도록 해제 */
   zoom: 0.9;
 }
-.ppt-wireframe:has(.mock ~ .mock ~ .mock ~ .mock) .mock { zoom: 0.68; }
+.ppt-wireframe:has(.mock ~ .mock ~ .mock ~ .mock) .mock { zoom: 0.77; }
 
 /* 목업 라벨 ("기본 상태" / "선택됨"). .mock 이 position:relative 이므로
    absolute 로 프레임 바로 위에 남색 타이틀 바로 놓는다 — .mock 의 column

--- a/skills/mobile-web-planner/scripts/check_badge_overflow.py
+++ b/skills/mobile-web-planner/scripts/check_badge_overflow.py
@@ -6,9 +6,9 @@
 같다. 목업 프레임 높이에서 상태바·헤더·탭바를 뺀 가시 높이를 계산해, 그 아래에
 놓인 배지를 보고한다.
 
-    .mock         높이 600 + border 2px x 2 (box-sizing: border-box 이므로 596 내부)
+    .mock         높이 694 + border 1px x 2 (box-sizing: border-box 이므로 692 내부)
     .mock-partial 높이 320 (팝업 위 회색 배경 힌트 블록만큼 body 가 줄어든다)
-    .mock-status  20 / .mock-header 약 51 / .mock-footer 약 37
+    .mock-status  26 / .mock-header 약 51 / .mock-footer 약 37 / .mock-footer-pill 54(44+하단 margin 10)
     .pointer-badge 높이 24
 
 사용법:
@@ -21,9 +21,10 @@ import sys
 from pathlib import Path
 
 BADGE_H = 24
-STATUS_H = 20
+STATUS_H = 26
 HEADER_H = 51
 FOOTER_H = 37
+PILL_H = 54
 
 
 def mock_blocks(slide_html):
@@ -41,13 +42,15 @@ def visible_height(is_partial, markup):
         hint = re.search(r'<div style="height:(\d+)px;background:#e2e8f0', markup)
         height = 320 - (int(hint.group(1)) if hint else 0)
     else:
-        height = 596
+        height = 692
     if 'class="mock-status"' in markup:
         height -= STATUS_H
     if 'class="mock-header"' in markup:
         height -= HEADER_H
     if 'class="mock-footer"' in markup:
         height -= FOOTER_H
+    if 'class="mock-footer-pill"' in markup:
+        height -= PILL_H
     return height
 
 


### PR DESCRIPTION
Closes #67

tossinvest 실사용과 Liquid Glass 샘플링 세션에서 사용자 승인된 룩을 템플릿 계약으로 반영한다.

## 변경

| 항목 | v1 | v2 |
|---|---|---|
| 헤더 | 3줄 (48+28+28) | **2줄 (24+24)** — 화면 Type·요구사항 ID 를 top-bar 에 흡수, 화면 ID·Location·작업자를 메타 행에 |
| 푸터 | 28px | 24px (3바 동일 높이) |
| 목업 | 320×600 (1.87:1) | **320×694 (2.17:1)** — 아이폰 17·S26 비율, 라운드 22px + 섀도 |
| 상태바 | 회색 블록 | **9:41 + 신호·배터리 글리프** (CSS data-URI, 마크업 무변경) |
| 탭 바 | 풀폭 mock-footer | **`mock-footer-pill`** 신규 — iOS 26 Liquid Glass 플로팅 필 44px, 활성 탭 유리 버블 |
| Description | 380px | 300px → 4-up 축소율 0.68→**0.77** |
| 밀도 기준 | 서술만 | **Figma 시안급 가이드** — 백 버튼(‹) 기본, 카드·아바타·스파크라인 스니펫 |

## 무회귀

- 검증기 앵커(`ppt-top-no`·`ppt-meta-id`·`ppt-meta-value`·`mock-caption`) 정규식 계약 불변 — `ppt-meta-id` 는 CSS 위치만 좌측으로.
- `ppt-head-bar`·`mock-footer`·`ppt-top-proj` 는 구버전 호환 유지 (정의 삭제 없음).
- `check_badge_overflow.py` 가시 높이 상수 재계산 (mock 692 · 상태바 26 · 필 54).

## 검증

- 스킬 테스트 110개 + `run_tests.sh` 64개 통과
- tossinvest 24슬라이드 실산출물 마이그레이션(헤더 14건·푸터 6건 스크립트 치환) → 검증기 3종 exit 0, badge-audit misaligned 0, 렌더 스크린샷 확인 (Page 자동 번호·리얼 상태바·필 탭 바)

🤖 Generated with [Claude Code](https://claude.com/claude-code)