### PR TITLE
fix(mobile-web-planner): 배지 정렬 검증기 mock-footer-pill 컨테이너 인식 (#69)

### DIFF
--- a/skills/mobile-web-planner/scripts/check_badge_alignment.py
+++ b/skills/mobile-web-planner/scripts/check_badge_alignment.py
@@ -36,8 +36,9 @@ BADGE_RE = re.compile(
 
 #: 배지를 담을 수 있는 컨테이너. 각각이 별도의 좌표 원점(position:relative)이므로
 #: 서로 다른 컨테이너의 top 값은 비교 대상이 아니다 — mock-footer 의 `top:9px` 는
-#: mock-body 의 `top:9px` 와 전혀 다른 위치다.
-CONTAINER_RE = re.compile(r'class="mock-(?:body|header|footer)"')
+#: mock-body 의 `top:9px` 와 전혀 다른 위치다. mock-footer-pill 도 자체
+#: position:relative 원점이므로 별도 컨테이너다 (이슈 #69).
+CONTAINER_RE = re.compile(r'class="mock-(?:body|header|footer|footer-pill)"')
 
 
 def badge_groups(slide_body):

--- a/skills/mobile-web-planner/tests/test_badge_alignment.py
+++ b/skills/mobile-web-planner/tests/test_badge_alignment.py
@@ -117,5 +117,19 @@ class TestHtmlCommentsIgnored(unittest.TestCase):
         self.assertTrue(any("겹친다" in x for x in cba.check(p)))
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestFooterPillContainer(unittest.TestCase):
+    """mock-footer-pill 은 별도 좌표 원점 — body 배지와 순서·겹침을 비교하지 않는다 (#69)."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def _check(self, html):
+        p = self.tmp / "x_storyboard.html"
+        p.write_text(html, encoding="utf-8")
+        return cba.check(p)
+
+    def test_pill_badge_not_compared_with_body(self):
+        html = slide("09.1", [[("mock-body", [badge("1-4", 205)]),
+                               ("mock-footer-pill", [badge("1-5", 10)])]])
+        self.assertEqual(self._check(html), [])


### PR DESCRIPTION
Closes #69

`mock-footer-pill`(#67 신규)이 `CONTAINER_RE` 에 없어 필 배지가 직전 `mock-body` 좌표 그룹으로 합산 → 순서 역전 오탐. 정규식에 `footer-pill` 추가 + 회귀 테스트 1건.

- tossinvest v2 콜드 재생성에서 실측 오탐 (09.1 필 배지 1-5 top:10px vs body 1-4 top:205px)
- 스킬 테스트 111개 + run_tests.sh 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)