### PR TITLE
feat(install): Antigravity 에이전트를 agy 플러그인으로 등록 (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `inst
 
 ## 설치 (Install)
 
+`--with-agent` 는 세 런타임에 각기 다른 방식으로 에이전트를 설치합니다 — Claude Code(`~/.claude/agents/` 심링크) · Codex(`~/.codex/agents/` 심링크) · **Antigravity(`agy plugin install` 로 `doksam-skills-agents` 플러그인 등록, `agy agents` 로 확인)**. Antigravity 는 설치 시점에 파일이 복사되므로 어댑터 수정 후에는 `./install.sh --with-agent` 를 다시 실행합니다. `agy` CLI 가 없으면 안내만 출력됩니다.
+
 [skills.sh](https://www.skills.sh) 생태계의 `skills` CLI 로 바로 설치할 수 있습니다.
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ usage() {
                       원본은 skills/<skill>/agents/ 가 소유한다
                         claude.md      -> .claude/agents/<skill>.md
                         codex.toml     -> .codex/agents/<skill_underscored>.toml
-                        antigravity.md -> Managed Agent 등록 원본 경로만 안내
+                        antigravity.md -> agy 플러그인으로 등록 (전역 설치 시)
   --dry-run           수행할 작업만 출력하고 파일시스템은 바꾸지 않는다
   --uninstall         이 레포를 가리키는 심링크를 제거한다
   --force             충돌하는 기존 항목을 교체한다
@@ -123,8 +123,10 @@ fi
 # 스킬별 Agent Adapter 를 런타임이 탐색하는 이름으로 매핑한다.
 #   skills/<skill>/agents/claude.md   -> <claude agents>/<skill>.md
 #   skills/<skill>/agents/codex.toml  -> <codex agents>/<skill_underscored>.toml
-# antigravity.md 는 Managed Agent 등록 원본이라 파일시스템 설치 대상이 아니고
-# 경로만 안내한다.
+# antigravity.md 는 agy 가 파일시스템 에이전트 디렉터리를 탐색하지 않으므로
+# (2026-08-02 agy 1.1.8 실측: ~/.gemini/config/agents/ 의 md 는 CLI 를 행 상태로
+# 만든다 — 이슈 #78) 플러그인 메커니즘으로 등록한다: agents/ 를 담은 플러그인을
+# 스테이징해 `agy plugin install` → ~/.gemini/config/plugins/<name>/ 에 복사된다.
 antigravity_sources=()
 if [[ $WITH_AGENT -eq 1 ]]; then
   for skill in "${SKILL_NAMES[@]}"; do
@@ -260,14 +262,66 @@ if [[ $WITH_AGENT -eq 1 ]]; then
       do_install "${agent_targets[$i]}" "${agent_sources[$i]}"
     fi
   done
+  # ---- Antigravity: 플러그인으로 에이전트 등록 (전역 설치에서만) ----
+  # 설치 시점에 ~/.gemini/config/plugins/ 로 복사되므로 antigravity.md 를
+  # 고친 뒤에는 --with-agent 재실행이 필요하다.
+  AGY_PLUGIN_NAME="doksam-skills-agents"
+  agy_status="원본 없음"
   # bash 3.2 는 set -u 아래에서 빈 배열 전개를 오류로 처리하므로 먼저 센다.
   if [[ ${#antigravity_sources[@]} -gt 0 ]]; then
-    for src in "${antigravity_sources[@]}"; do
-      echo "info      Antigravity Managed Agent 등록 원본: $src"
-    done
+    if [[ -n "$PROJECT" ]]; then
+      agy_status="프로젝트 설치 미지원 — 전역(--project 없이)에서 플러그인으로 등록된다"
+      echo "info      Antigravity 에이전트는 전역 플러그인 등록만 지원한다"
+    elif ! command -v agy >/dev/null 2>&1; then
+      agy_status="건너뜀 — agy CLI 없음"
+      echo "info      agy CLI 가 없어 Antigravity 에이전트를 등록하지 못했다."
+      echo "info      agy 설치 후 다시 실행하거나, 아래 원본으로 직접 플러그인을 만들면 된다:"
+      for src in "${antigravity_sources[@]}"; do
+        echo "info        $src"
+      done
+    elif [[ $DRY_RUN -eq 1 ]]; then
+      agy_status="dry-run — 플러그인 '$AGY_PLUGIN_NAME' 등록 예정 (${#antigravity_sources[@]}개)"
+      echo "plan      agy plugin install ($AGY_PLUGIN_NAME, 에이전트 ${#antigravity_sources[@]}개)"
+    else
+      staging="$(mktemp -d "${TMPDIR:-/tmp}/doksam-skills-agy.XXXXXX")"
+      mkdir -p "$staging/agents"
+      printf '{"name": "%s", "description": "doksam-skills Agent Adapter 모음 (install.sh 가 생성)", "version": "1.0.0"}\n' \
+        "$AGY_PLUGIN_NAME" > "$staging/plugin.json"
+      for skill in "${SKILL_NAMES[@]}"; do
+        adapter="$REPO_ROOT/skills/$skill/agents/antigravity.md"
+        [[ -f "$adapter" ]] && cp "$adapter" "$staging/agents/$skill.md"
+      done
+      if [[ "$ACTION" == "uninstall" ]]; then
+        if agy plugin uninstall "$AGY_PLUGIN_NAME" >/dev/null 2>&1; then
+          agy_status="플러그인 '$AGY_PLUGIN_NAME' 제거됨"
+          echo "remove    agy plugin $AGY_PLUGIN_NAME"
+          ok=$((ok + 1))
+        else
+          agy_status="플러그인 없음 (제거 생략)"
+          echo "skip      agy plugin $AGY_PLUGIN_NAME (등록돼 있지 않음)"
+          skipped=$((skipped + 1))
+        fi
+      else
+        # 재실행 시 최신 원본으로 갱신되도록 기존 등록을 먼저 지운다.
+        agy plugin uninstall "$AGY_PLUGIN_NAME" >/dev/null 2>&1 || true
+        if agy plugin install "$staging" >/dev/null 2>&1; then
+          agy_status="플러그인 '$AGY_PLUGIN_NAME' 등록 (에이전트 ${#antigravity_sources[@]}개 — 'agy agents' 로 확인)"
+          echo "plugin    agy plugin $AGY_PLUGIN_NAME (에이전트 ${#antigravity_sources[@]}개)"
+          ok=$((ok + 1))
+        else
+          agy_status="등록 실패 — 'agy plugin install $staging' 를 직접 실행해 오류를 확인할 것"
+          echo "fail      agy plugin install (수동 확인 필요: $staging)" >&2
+          failed=$((failed + 1))
+        fi
+      fi
+      [[ "$agy_status" == 등록\ 실패* ]] || rm -rf "$staging"
+    fi
   fi
 fi
 
 echo
+if [[ $WITH_AGENT -eq 1 ]]; then
+  echo "런타임별 에이전트: Claude=심링크 · Codex=심링크 · Antigravity=$agy_status"
+fi
 echo "완료: ok=$ok skip=$skipped conflict=$failed"
 [[ $failed -eq 0 ]]

--- a/skills/doksam-ui/agents/antigravity.md
+++ b/skills/doksam-ui/agents/antigravity.md
@@ -1,3 +1,8 @@
+---
+name: doksam-ui
+description: doksam 프로젝트 UI 를 ui.doksam.com 표준(디자인 토큰·컴포넌트 레지스트리·규칙)에 맞춰 만드는 프론트엔드 개발자
+---
+
 # doksam-ui
 
 doksam 프로젝트 UI 를 ui.doksam.com 표준(디자인 토큰·컴포넌트 레지스트리·규칙)에 맞춰 만드는 프론트엔드 개발자

--- a/skills/mobile-web-planner/agents/antigravity.md
+++ b/skills/mobile-web-planner/agents/antigravity.md
@@ -1,3 +1,8 @@
+---
+name: mobile-web-planner
+description: 모바일 웹·앱 IA와 PPT 스타일 화면설계서를 작성하거나 수정할 때 사용하는 UX/UI 수석 기획자
+---
+
 # Mobile Web Planner Agent
 
 당신은 모바일 웹·앱 UX/UI 수석 기획자다.

--- a/skills/nextjs-implementer/agents/antigravity.md
+++ b/skills/nextjs-implementer/agents/antigravity.md
@@ -1,3 +1,8 @@
+---
+name: nextjs-implementer
+description: mobile-web-planner 화면설계서와 Business Rules 를 구현으로 이어가는 시니어 웹 개발자
+---
+
 # nextjs-implementer
 
 mobile-web-planner 화면설계서와 Business Rules 를 구현으로 이어가는 시니어 웹 개발자 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택.

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -21,6 +21,18 @@ fi
 SKILL="${SKILLS[0]}"
 SRC="$REPO_ROOT/skills/$SKILL"
 
+# agy CLI 스텁 — 실제 agy 를 호출하지 않고 인자만 기록한다 (이슈 #78).
+# PATH 맨 앞에 두어 install.sh 의 `command -v agy` 와 호출을 가로챈다.
+STUB_BIN="$(mktemp -d)"
+AGY_LOG="$STUB_BIN/agy.log"
+cat > "$STUB_BIN/agy" <<STUB
+#!/usr/bin/env bash
+echo "\$@" >> "$AGY_LOG"
+exit 0
+STUB
+chmod +x "$STUB_BIN/agy"
+export PATH="$STUB_BIN:$PATH"
+
 # Agent Adapter 동작을 확인할 대표 스킬 (claude.md 를 가진 첫 스킬)
 AGENT_SKILL=""
 for s in "${SKILLS[@]}"; do
@@ -95,7 +107,8 @@ check "exit code" "0" "$?"
 check "Claude Agent" "$CLAUDE_AGENT_SRC" "$(readlink "$HOME/$CLAUDE_AGENT_LINK" 2>/dev/null)"
 check "Codex Agent" "$CODEX_AGENT_SRC" "$(readlink "$HOME/$CODEX_AGENT_LINK" 2>/dev/null)"
 check "Agent 원본은 스킬 소유" "present" "$([[ "$CLAUDE_AGENT_SRC" == "$REPO_ROOT/skills/"* ]] && echo present || echo absent)"
-check "Antigravity 원본 안내" "present" "$(grep -q '^info.*Antigravity Managed Agent 등록 원본:' <<<"$out" && echo present || echo absent)"
+check "agy 스텁이 plugin install 을 받음" "present" "$(grep -q '^plugin install ' "$AGY_LOG" && echo present || echo absent)"
+check "런타임별 요약에 Antigravity 등록" "present" "$(grep -q '^런타임별 에이전트: .*Antigravity=플러그인' <<<"$out" && echo present || echo absent)"
 drop_sandbox
 
 echo "test: --skill-only 와 --with-agent 를 함께 쓰면 실패한다"
@@ -193,7 +206,9 @@ drop_sandbox
 echo "test: --uninstall --with-agent 는 Agent 심링크도 제거한다"
 new_sandbox
 "$INSTALL" --with-agent >/dev/null 2>&1
+: > "$AGY_LOG"
 "$INSTALL" --uninstall --with-agent >/dev/null 2>&1
+check "agy 스텁이 plugin uninstall 을 받음" "present" "$(grep -q '^plugin uninstall ' "$AGY_LOG" && echo present || echo absent)"
 check "exit code" "0" "$?"
 check "Claude Agent 제거" "absent" "$([[ -e "$HOME/$CLAUDE_AGENT_LINK" ]] && echo present || echo absent)"
 check "Codex Agent 제거" "absent" "$([[ -e "$HOME/$CODEX_AGENT_LINK" ]] && echo present || echo absent)"


### PR DESCRIPTION
## 문제 (#78)

`--with-agent` 가 Claude/Codex 에는 심링크를 설치하지만 Antigravity 는 경로만 안내해 `agy agents` 가 비어 있었다.

## 실측 (agy 1.1.8)

- `~/.gemini/config/agents/*.md` 파일시스템 등록: **미지원** — md 를 넣으면 `agy agents` 가 행(hang) 상태가 된다
- `agy plugin install <dir>` (plugin.json + agents/*.md): **동작** — `~/.gemini/config/plugins/<name>/` 로 복사 등록
- agents md 에 **frontmatter(name/description)가 없으면 등록은 되지만 목록에 나타나지 않는다**

## 변경

- install.sh: 전역 `--with-agent` 에서 antigravity.md 3종을 `doksam-skills-agents` 플러그인으로 스테이징해 `agy plugin install` (재실행 시 재등록으로 갱신), `--uninstall` 은 plugin uninstall. agy 부재 시 실행 가능한 안내 출력. 종료 요약에 런타임별 결과 구분(`런타임별 에이전트: Claude=심링크 · Codex=심링크 · Antigravity=…`)
- antigravity.md 3종에 frontmatter 추가
- tests: agy 스텁(PATH 선점)으로 install/uninstall 인자 검증 — 실제 agy 불필요
- README: 런타임별 설치 방식과 재실행 필요성 문서화

## 검증 (수용 기준)

- 이 머신 실측: `./install.sh --with-agent` 후 `agy agents` 에 **doksam-ui / mobile-web-planner / nextjs-implementer 3종 표시**
- install.sh 출력만으로 agy 설치 결과를 구분 가능
- `./scripts/run_tests.sh` 전부 통과 (pass=72 포함)

Closes #78