### PR TITLE
feat(install): --vendor — vendoring 사본 갱신 경로 (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `inst
 
 ## 설치 (Install)
 
+설치 경로는 두 가지입니다.
+
+1. **전역 설치 (기본)** — `./install.sh` 가 홈 디렉터리의 세 런타임 경로에 **심링크**를 만듭니다. 이 리포에서 스킬을 고치면 즉시 반영됩니다.
+2. **프로젝트 vendoring** — 팀/다른 머신과 공유하려고 프로젝트 리포에 사본을 커밋한 경우(`<프로젝트>/.agents/skills/`), 전역 재설치로는 갱신되지 않습니다. **`./install.sh --vendor <프로젝트dir>`** 로 파일 단위 갱신합니다 — 심링크가 아닌 복사라 다른 머신에서도 동작하고, 실행 후 `git status` 요약으로 커밋 대상이 바로 보입니다. `--dry-run`(예고만), `--check`(차이 유무를 종료코드로 — 훅에서 뒤처짐 감지용), `--skill <name>`(선택 갱신)을 지원하며, 사본에만 있는 파일은 보고만 하고 지우지 않습니다.
+
 `--with-agent` 는 세 런타임에 각기 다른 방식으로 에이전트를 설치합니다 — Claude Code(`~/.claude/agents/` 심링크) · Codex(`~/.codex/agents/` 심링크) · **Antigravity(`agy plugin install` 로 `doksam-skills-agents` 플러그인 등록, `agy agents` 로 확인)**. Antigravity 는 설치 시점에 파일이 복사되므로 어댑터 수정 후에는 `./install.sh --with-agent` 를 다시 실행합니다. `agy` CLI 가 없으면 안내만 출력됩니다.
 
 [skills.sh](https://www.skills.sh) 생태계의 `skills` CLI 로 바로 설치할 수 있습니다.

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ SELECTION=""
 DRY_RUN=0
 FORCE=0
 PROJECT=""
+VENDOR=""
+VENDOR_CHECK=0
+VENDOR_SKILLS=()
 
 ok=0
 skipped=0
@@ -43,6 +46,13 @@ usage() {
                         claude.md      -> .claude/agents/<skill>.md
                         codex.toml     -> .codex/agents/<skill_underscored>.toml
                         antigravity.md -> agy 플러그인으로 등록 (전역 설치 시)
+  --vendor <dir>      프로젝트에 vendoring 된 스킬 사본(<dir>/.agents/skills/)을
+                      리포 최신본으로 파일 단위 갱신한다 — 심링크가 아니라 복사이며,
+                      사본에만 있는 파일은 보고만 하고 지우지 않는다.
+                      __pycache__/*.pyc/.DS_Store 는 제외한다
+    --skill <name>    갱신할 스킬을 지정한다 (반복 가능, 미지정 시 사본에 이미
+                      있는 스킬만 갱신)
+    --check           갱신 없이 차이 유무만 종료코드로 반환한다 (0=최신, 1=뒤처짐)
   --dry-run           수행할 작업만 출력하고 파일시스템은 바꾸지 않는다
   --uninstall         이 레포를 가리키는 심링크를 제거한다
   --force             충돌하는 기존 항목을 교체한다
@@ -81,6 +91,19 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       PROJECT="$2"; shift 2 ;;
+    --vendor)
+      if [[ $# -lt 2 ]]; then
+        echo "오류: --vendor 에 디렉터리 인자가 필요하다" >&2
+        exit 1
+      fi
+      VENDOR="$2"; shift 2 ;;
+    --check)     VENDOR_CHECK=1; shift ;;
+    --skill)
+      if [[ $# -lt 2 ]]; then
+        echo "오류: --skill 에 스킬명 인자가 필요하다" >&2
+        exit 1
+      fi
+      VENDOR_SKILLS+=("$2"); shift 2 ;;
     -h|--help)   usage; exit 0 ;;
     *)
       echo "오류: 알 수 없는 옵션 '$1'" >&2
@@ -92,6 +115,99 @@ done
 if [[ ${#SKILL_NAMES[@]} -eq 0 ]]; then
   echo "오류: skills/ 아래에 SKILL.md 를 가진 스킬이 없다" >&2
   exit 1
+fi
+
+# ---- vendoring 사본 갱신 (이슈 #79) ----
+# 프로젝트 리포에 커밋된 스킬 사본은 전역 심링크 재설치로는 갱신되지 않는다.
+# 여기서 파일 단위로 리포 -> 사본 을 반영한다. 심링크를 만들지 않으며,
+# 사본에만 있는 파일(로컬 수정분일 수 있다)은 보고만 하고 지우지 않는다.
+vendor_excluded() {
+  case "$1" in
+    *__pycache__*|*.pyc|*.DS_Store) return 0 ;;
+  esac
+  return 1
+}
+
+if [[ -n "$VENDOR" ]]; then
+  if [[ -n "$PROJECT" || "$ACTION" == "uninstall" || $WITH_AGENT -eq 1 ]]; then
+    echo "오류: --vendor 는 --project/--uninstall/--with-agent 와 함께 쓸 수 없다" >&2
+    exit 1
+  fi
+  if [[ ! -d "$VENDOR" ]]; then
+    echo "오류: --vendor 대상이 디렉터리가 아니다 — $VENDOR" >&2
+    exit 1
+  fi
+  vendor_root="$(cd "$VENDOR" && pwd)/.agents/skills"
+
+  # 대상 스킬: --skill 지정분, 없으면 사본에 이미 있는 스킬만
+  vendor_targets=()
+  if [[ ${#VENDOR_SKILLS[@]} -gt 0 ]]; then
+    for s in "${VENDOR_SKILLS[@]}"; do
+      if [[ ! -d "$REPO_ROOT/skills/$s" ]]; then
+        echo "오류: 리포에 없는 스킬 — $s" >&2
+        exit 1
+      fi
+      vendor_targets+=("$s")
+    done
+  else
+    for s in "${SKILL_NAMES[@]}"; do
+      [[ -d "$vendor_root/$s" ]] && vendor_targets+=("$s")
+    done
+    if [[ ${#vendor_targets[@]} -eq 0 ]]; then
+      echo "오류: $vendor_root 에 vendoring 된 스킬이 없다 — 새로 넣으려면 --skill <name>" >&2
+      exit 1
+    fi
+  fi
+
+  adds=0; updates=0; orphans=0
+  for s in "${vendor_targets[@]}"; do
+    src="$REPO_ROOT/skills/$s"
+    dst="$vendor_root/$s"
+    while IFS= read -r f; do
+      rel="${f#"$src"/}"
+      vendor_excluded "$rel" && continue
+      if [[ ! -f "$dst/$rel" ]]; then
+        echo "add       $s/$rel"
+        adds=$((adds + 1))
+      elif ! cmp -s "$f" "$dst/$rel"; then
+        echo "update    $s/$rel"
+        updates=$((updates + 1))
+      else
+        continue
+      fi
+      if [[ $DRY_RUN -eq 0 && $VENDOR_CHECK -eq 0 ]]; then
+        mkdir -p "$(dirname "$dst/$rel")"
+        cp -p "$f" "$dst/$rel"
+      fi
+    done < <(find "$src" -type f | sort)
+    if [[ -d "$dst" ]]; then
+      while IFS= read -r f; do
+        rel="${f#"$dst"/}"
+        vendor_excluded "$rel" && continue
+        if [[ ! -f "$src/$rel" ]]; then
+          echo "orphan    $s/$rel (원본에 없음 — 로컬 수정분일 수 있어 지우지 않는다)"
+          orphans=$((orphans + 1))
+        fi
+      done < <(find "$dst" -type f | sort)
+    fi
+  done
+
+  echo
+  if [[ $VENDOR_CHECK -eq 1 ]]; then
+    echo "check: add=$adds update=$updates orphan=$orphans (변경 없음)"
+    [[ $((adds + updates)) -eq 0 ]]
+    exit $?
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "dry-run: add=$adds update=$updates orphan=$orphans (변경 없음)"
+    exit 0
+  fi
+  echo "vendor 갱신: add=$adds update=$updates orphan=$orphans -> $vendor_root"
+  if git -C "$VENDOR" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "-- git status (커밋 대상 확인):"
+    git -C "$VENDOR" status --short -- .agents/skills | head -40
+  fi
+  exit 0
 fi
 
 # 타깃 목록 구성

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -221,6 +221,39 @@ new_sandbox
 check "복사본 보존" "present" "$([[ -f "$HOME/.claude/skills/$SKILL/SKILL.md" ]] && echo present || echo absent)"
 drop_sandbox
 
+echo "test: --vendor 는 사본을 파일 단위로 갱신하고 orphan 은 지우지 않는다"
+reset_home
+vproj="$(mktemp -d)"
+git -C "$vproj" init -q
+mkdir -p "$vproj/.agents/skills/$SKILL"
+cp -R "$SRC/." "$vproj/.agents/skills/$SKILL/"
+echo "낡은 내용" > "$vproj/.agents/skills/$SKILL/SKILL.md"          # 뒤처진 파일
+echo "로컬 전용" > "$vproj/.agents/skills/$SKILL/local-note.md"      # orphan
+mkdir -p "$REPO_ROOT/skills/$SKILL/__pycache__"
+echo x > "$REPO_ROOT/skills/$SKILL/__pycache__/t.pyc"                # 제외 대상
+"$INSTALL" --vendor "$vproj" --check >/dev/null 2>&1
+check "--check 는 뒤처지면 exit 1" "1" "$?"
+out="$("$INSTALL" --vendor "$vproj" --dry-run 2>&1)"
+check "dry-run 이 update 를 예고" "present" "$(grep -q "^update    $SKILL/SKILL.md" <<<"$out" && echo present || echo absent)"
+check "dry-run 후에도 사본은 그대로" "낡은 내용" "$(cat "$vproj/.agents/skills/$SKILL/SKILL.md")"
+out="$("$INSTALL" --vendor "$vproj" 2>&1)"
+check "vendor 갱신 exit 0" "0" "$?"
+check "사본이 원본과 동일해짐" "same" "$(cmp -s "$SRC/SKILL.md" "$vproj/.agents/skills/$SKILL/SKILL.md" && echo same || echo diff)"
+check "orphan 보존" "로컬 전용" "$(cat "$vproj/.agents/skills/$SKILL/local-note.md")"
+check "orphan 보고" "present" "$(grep -q "^orphan    $SKILL/local-note.md" <<<"$out" && echo present || echo absent)"
+check "__pycache__ 미복사" "absent" "$([[ -e "$vproj/.agents/skills/$SKILL/__pycache__" ]] && echo present || echo absent)"
+check "git status 요약 출력" "present" "$(grep -q '^-- git status' <<<"$out" && echo present || echo absent)"
+"$INSTALL" --vendor "$vproj" --check >/dev/null 2>&1
+check "--check 는 최신이면 exit 0" "0" "$?"
+rm -rf "$REPO_ROOT/skills/$SKILL/__pycache__" "$vproj"
+
+echo "test: --vendor 는 설치 플래그와 배타적이다"
+reset_home
+vproj2="$(mktemp -d)"; mkdir -p "$vproj2/.agents/skills/$SKILL"
+"$INSTALL" --vendor "$vproj2" --with-agent >/dev/null 2>&1
+check "--vendor --with-agent 거부" "1" "$?"
+rm -rf "$vproj2"
+
 echo "test: --uninstall 은 남의 심링크를 건드리지 않는다"
 new_sandbox
 decoy="$SANDBOX/decoy"


### PR DESCRIPTION
## 문제 (#79)

프로젝트 리포에 스킬을 vendoring 한 경우(예: tossinvest `.agents/skills/`) 전역 재설치는 심링크만 다시 만들어 사본이 조용히 뒤처진다. `--project --force` 는 추적 중인 사본을 지우고 절대경로 심링크로 덮어써 다른 머신에서 깨진다.

## 변경

```
./install.sh --vendor <dir>              # 리포 → <dir>/.agents/skills/ 파일 단위 반영
./install.sh --vendor <dir> --dry-run    # 무엇이 바뀔지만 출력
./install.sh --vendor <dir> --check      # 차이 유무만 종료코드 (0=최신, 1=뒤처짐)
./install.sh --vendor <dir> --skill <s>  # 선택 갱신 (신규 vendoring 도 이 경로)
```

- 심링크를 만들지 않는다. 기본 대상은 **사본에 이미 있는 스킬**만
- 사본에만 있는 파일은 `orphan` 으로 보고만 하고 지우지 않는다 (로컬 수정분 보호)
- `__pycache__`/`*.pyc`/`.DS_Store` 제외
- 대상이 git 리포면 실행 후 `git status --short` 요약 출력 — 커밋 대상이 바로 보인다
- 설치 플래그(--project/--uninstall/--with-agent)와 배타

## 검증 (수용 기준)

- 테스트 11케이스 추가: 뒤처진 파일 갱신 → 원본과 동일, dry-run 무변경, orphan 보존+보고, pycache 미복사, check 종료코드 1→0, git 요약 출력, 배타 플래그 거부 — `./tests/test_install.sh` pass=83
- README 에 전역 설치 / 프로젝트 vendoring 두 경로 구분 문서화

Closes #79