### PR TITLE
feat(session-recording): 오디오 원본 m4a 병행 저장 (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Claude Code, Codex, Antigravity 에서 쓰는 Agent Skill 모음입니다. `inst
 | [memory-factcheck](skills/memory-factcheck/SKILL.md) | 에이전트 영속 메모리를 코드·DB·이슈 등 실제 근거와 대조해 낡은 기억을 교정하는 감사 스킬 |
 | [nextjs-implementer](skills/nextjs-implementer/SKILL.md) | mobile-web-planner 의 화면설계서·Business Rules 한 쌍을 받아 구현으로 이어가는 후속 스킬 — 프론트는 Next.js + React, 백엔드는 Next.js 풀스택 또는 Java 1.8 API 서버 중 선택 |
 | [doksam-ui](skills/doksam-ui/SKILL.md) | doksam 프로젝트 UI 를 ui.doksam.com 표준(SSOT)에 맞춰 만드는 스킬 — 시맨틱 토큰·브랜드 프로필·shadcn 커스텀 레지스트리·표준 준수 체크리스트 강제 |
-| [session-recording](skills/session-recording/SKILL.md) | 강의·회의·교육 세션을 whisper-stream 으로 실시간 전사하고 10분 간격 증분 요약 루프를 도는 스킬 — 환각 필터, 오프셋 기반 증분 읽기, 종료 후 정리본·보고용 요약 생성 |
+| [session-recording](skills/session-recording/SKILL.md) | 강의·회의·교육 세션을 whisper-stream 으로 실시간 전사하고 오디오 원본(m4a)을 병행 저장하며 10분 간격 증분 요약 루프를 도는 스킬 — 환각 필터, 오프셋 기반 증분 읽기, 종료 후 정리본·보고용 요약 생성 |
 
 ## Mobile Web Planner
 

--- a/skills/session-recording/SKILL.md
+++ b/skills/session-recording/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: session-recording
-description: 사용자가 "녹음시작" / "녹음 시작" / "강의 녹음" / "회의 녹음" / "전사 시작" 이라고 하거나, 실시간 강의·회의·교육 세션의 녹음과 요약을 요청할 때 사용한다. 실행을 멈추는 "녹음종료" / "녹음 끝" 도 이 스킬이 처리한다.
+description: 사용자가 "녹음시작" / "녹음 시작" / "강의 녹음" / "회의 녹음" / "전사 시작" 이라고 하거나, 실시간 강의·회의·교육 세션의 녹음과 요약을 요청할 때 사용한다. 실시간 전사와 함께 오디오 원본(m4a)도 저장한다. 실행을 멈추는 "녹음종료" / "녹음 끝" 도 이 스킬이 처리한다.
 ---
 
 # 세션 실시간 녹음·요약 (강의·회의·교육)
 
-whisper-stream으로 마이크 입력을 실시간 전사하고, 10분 간격 루프로 누적 요약과 질문 후보를 갱신한다. 회차 산출물은 전부 작업 디렉터리 아래 `session-<YYYY-MM-DD>/` 안에 모은다 (기존 자료가 `lecture-<날짜>/` 관례를 쓰는 레포면 그 관례를 따른다).
+whisper-stream으로 마이크 입력을 실시간 전사하고, ffmpeg로 오디오 원본(`session.m4a`)을 병행 저장하며, 10분 간격 루프로 누적 요약과 질문 후보를 갱신한다. 회차 산출물은 전부 작업 디렉터리 아래 `session-<YYYY-MM-DD>/` 안에 모은다 (기존 자료가 `lecture-<날짜>/` 관례를 쓰는 레포면 그 관례를 따른다).
 
 ## 전제 조건
 
 - `whisper-stream` 바이너리(whisper.cpp의 stream 예제)와 한국어 지원 모델이 설치돼 있어야 한다. 시작 전에 한 번 확인하고, 없으면 사용자에게 설치 여부를 먼저 묻는다 — 임의로 대용량 모델을 다운로드하지 않는다.
   - 바이너리: `command -v whisper-stream` (macOS는 `brew install whisper-cpp` 계열로 설치 가능)
   - 모델: `~/models/whisper/ggml-large-v3-turbo.bin` (기본 가정 경로 — 다르면 사용자에게 확인)
+- 오디오 원본 저장에는 `ffmpeg` 가 필요하다 (`command -v ffmpeg`, macOS 는 `brew install ffmpeg`).
+  없으면 사용자에게 설치 여부를 묻고, 설치를 원치 않으면 **전사만으로 진행한다** — 오디오
+  저장이 없으면 부정확한 구간을 재청취·재전사할 수 없다는 점을 한 줄 알린다.
 - 이미 설치돼 있으면 재설치·재다운로드하지 않는다.
 
 ## 트리거
@@ -40,15 +43,29 @@ whisper-stream으로 마이크 입력을 실시간 전사하고, 10분 간격 �
    - `Bash run_in_background=true`로 띄운다. **`disown` 금지** — harness가 프로세스를 추적하지 못한다.
    - 온라인 세션(Zoom/Teams)이면 마이크 대신 BlackHole 등 시스템 오디오 캡처를 쓰는 게 음질이 낫다. 사용자가 온라인이라고 하면 이 점을 알린다.
 
-3. **30초쯤 뒤 `transcript.txt`에 실제 텍스트가 쌓이는지 한 번 확인하고 보고한다.** 파일이 비어 있으면 마이크 권한·입력 장치를 먼저 점검한다. 확인 없이 "시작했습니다"만 보고하지 않는다.
+3. **오디오 원본 병행 녹음** — ffmpeg 가 있으면 같은 입력을 m4a 로 저장한다 (whisper 와 별개 프로세스, macOS CoreAudio 는 같은 입력 장치의 동시 캡처를 허용한다):
 
-4. 요약 루프를 건다 — `loop` 스킬로 10분 간격:
+   ```bash
+   cd session-$(date +%F) && ffmpeg -f avfoundation -i ":0" -ac 1 -c:a aac -b:a 64k      -movflags +frag_keyframe+empty_moov session.m4a
+   ```
+
+   - 역시 `run_in_background=true`, `disown` 금지.
+   - `:0` 은 기본 오디오 입력 인덱스다. 장치가 여럿(BlackHole 등)이면
+     `ffmpeg -f avfoundation -list_devices true -i ""` 로 인덱스를 확인해 **whisper-stream 과
+     같은 입력**을 잡는다.
+   - `frag_keyframe+empty_moov` 는 프로세스가 비정상 종료해도 그 시점까지의 오디오가
+     재생 가능하게 남도록 하는 안전장치다 (일반 m4a 는 정상 종료 전에 죽으면 통째로 깨진다).
+   - AAC 64k 모노 기준 2시간에 약 55MB.
+
+4. **30초쯤 뒤 `transcript.txt`에 실제 텍스트가 쌓이는지, `session.m4a` 크기가 커지는지 한 번 확인하고 보고한다.** transcript 가 비어 있으면 마이크 권한·입력 장치를 먼저 점검한다. 확인 없이 "시작했습니다"만 보고하지 않는다.
+
+5. 요약 루프를 건다 — `loop` 스킬로 10분 간격:
 
    ```
    /loop 10m 세션 전사 증분 요약 (session-<날짜>)
    ```
 
-5. 읽은 바이트 오프셋을 대화 안에서 계속 들고 간다. 초기값 1.
+6. 읽은 바이트 오프셋을 대화 안에서 계속 들고 간다. 초기값 1.
 
 ## 매 회차 절차
 
@@ -76,8 +93,14 @@ whisper-stream으로 마이크 입력을 실시간 전사하고, 10분 간격 �
 ## 종료 절차
 
 1. whisper-stream 프로세스를 종료한다 (`TaskStop` 또는 `pkill -f whisper-stream`).
+   ffmpeg 는 **반드시 SIGINT 로** 종료한다 (`pkill -INT -f 'ffmpeg.*session.m4a'`) — 정상
+   마무리 쓰기가 일어나야 하며, `kill -9` 는 마지막 조각을 잃는다. 종료 후
+   `ffprobe -v error -show_entries format=duration session.m4a` 로 길이가 세션 시간과
+   비슷한지 확인한다.
 2. **루프를 반드시 해제한다.** 끝난 뒤에도 계속 돌면 빈 요약이 쌓인다.
 3. 최종 산출물을 만든다:
+   - `session.m4a` — 오디오 원본. **절대 덮어쓰지 않는다.** 전사가 의심스러운 구간의
+     재청취·재전사(`whisper-cli -f session.m4a`)용 근거다.
    - `transcript.txt` — 원본. **절대 덮어쓰지 않는다.**
    - `transcript_<세션>_cleaned.txt` — 정리본. 환각 grep 제거 → 1,000줄 내외로 분할 → sonnet 서브에이전트 3~4개 병렬. 프롬프트에 **세션 맥락 + 자주 깨지는 용어 매핑**을 반드시 넣는다. 없으면 고유명사가 전부 엉뚱하게 복원된다.
    - `summary_<세션명>_<날짜>.md` — 보고용 요약본(교육요약·회의록 등 성격에 맞게). 표준/격식 톤.
@@ -94,3 +117,5 @@ whisper-stream으로 마이크 입력을 실시간 전사하고, 10분 간격 �
 | 정리본을 `transcript.txt`에 덮어쓰기 | 원본 소실. 복구 불가. |
 | 서브에이전트에 용어집 없이 교정 지시 | 고유명사가 전부 창작된다. |
 | 세션 끝나고 루프 방치 | 빈 요약이 계속 쌓인다. |
+| ffmpeg 를 `kill -9` 로 종료 | 마지막 조각 소실. SIGINT 로 종료한다. |
+| whisper 와 ffmpeg 가 다른 입력 장치를 잡음 | 전사와 오디오 내용이 어긋난다. 시작 확인 때 둘 다 점검. |


### PR DESCRIPTION
## 변경 (#94)

whisper-stream 은 텍스트만 남겨 부정확한 구간의 재청취·재전사가 불가능했다. 시작 절차에 ffmpeg(avfoundation) 병렬 녹음을 추가한다.

- `session.m4a` — AAC 64k 모노 (2시간 ~55MB). `frag_keyframe+empty_moov` 로 프로세스가 비정상 종료해도 그 시점까지 재생 가능
- 종료는 SIGINT (일반 kill 은 마지막 조각 소실) + ffprobe 길이 확인
- ffmpeg 부재 시 사용자 확인 후 전사만으로 진행
- 시작 확인 단계에 m4a 크기 증가 점검, 실수 표에 kill -9 금지·입력 장치 불일치 추가

## 검증

- 이 맥 실측: 동일 플래그 3초 캡처 → ffprobe duration=3.02s, 재생 가능 파일 생성 확인
- `./scripts/run_tests.sh` 전부 통과

Closes #94