### PR TITLE
fix(tests): 레이아웃 검사에서 git 이 무시하는 항목을 제외한다 (#112)

### DIFF
--- a/tests/test_skill_layout.py
+++ b/tests/test_skill_layout.py
@@ -15,6 +15,7 @@
   .codex/agents/<skill_us>.toml  codex.toml 이 있으면 그것을 가리키는 심링크
 """
 import re
+import subprocess
 import tomllib
 import unittest
 from pathlib import Path
@@ -27,6 +28,25 @@ ALLOWED_ADAPTERS = {"claude.md", "codex.toml", "antigravity.md", "openai.yaml"}
 
 def skill_dirs():
     return sorted(d for d in SKILLS_DIR.iterdir() if (d / "SKILL.md").is_file())
+
+
+def git_ignores(path: Path) -> bool:
+    """git 이 무시하는 경로인가.
+
+    레이아웃 검사 대상은 저장소에 들어가는 것이지 작업 디렉터리에 굴러다니는
+    무엇이 아니다. macOS Finder 의 .DS_Store 처럼 .gitignore 에 이미 있는
+    아티팩트가 테스트를 빨간불로 만들면 안 된다 (이슈 #112). 허용 목록에
+    이름을 하나씩 늘리는 방식은 다음 아티팩트에서 또 깨진다.
+
+    git 을 쓸 수 없는 환경에서는 무시 판정을 포기하고 전부 검사한다.
+    """
+    try:
+        return subprocess.run(
+            ["git", "check-ignore", "-q", str(path)],
+            cwd=REPO_ROOT, capture_output=True, check=False,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
 
 
 def frontmatter(text: str) -> str:
@@ -51,10 +71,12 @@ class TestSkillsDiscovered(unittest.TestCase):
     def test_skill_dir_has_no_unexpected_top_level_entries(self):
         allowed = {
             "SKILL.md", "agents", "resources", "scripts", "tests", "docs",
-            "references", "assets", "__pycache__",
+            "references", "assets",
         }
         for skill in skill_dirs():
             for entry in skill.iterdir():
+                if git_ignores(entry):
+                    continue
                 with self.subTest(skill=skill.name, entry=entry.name):
                     self.assertIn(entry.name, allowed)
 


### PR DESCRIPTION
Closes #112

#111 머지 직후 정식 클론에서 `./scripts/run_tests.sh` 를 돌리니 실패했다.

```
FAIL: test_skill_dir_has_no_unexpected_top_level_entries (skill='doksam-ui', entry='.DS_Store')
--- FAIL: repo tests
```

macOS Finder 가 스킬 디렉터리에 만든 `.DS_Store` 다. **`.gitignore` 에 이미 있고 추적되지도 않는다** (`git ls-files | grep -c DS_Store` → 0). 저장소 레이아웃은 멀쩡한데 머신 로컬 아티팩트가 빨간불을 만들었다.

## 변경

이 테스트가 검사하려는 것은 **저장소에 들어가는** 스킬 디렉터리 구성이지 작업 디렉터리에 굴러다니는 무엇이 아니다. `git check-ignore` 로 판정해 무시 대상은 건너뛴다. git 을 쓸 수 없는 환경에서는 지금처럼 전부 검사한다(판정 포기 시 `False`).

허용 목록에서 `__pycache__` 도 뺐다. 이미 `.gitignore` 에 있어 새 판정으로 걸러지고, 개별 이름을 늘려가는 방식은 다음 OS 아티팩트에서 또 깨진다.

## 확인

`.DS_Store` 2개와 `__pycache__/x.pyc` 를 심고:

```
Ran 11 tests — OK
```

같은 상태에서 진짜 위반인 `junk.txt` 를 추가하면:

```
FAIL: ... (skill='doksam-ui', entry='junk.txt')
AssertionError: 'junk.txt' not found in {'docs', 'assets', 'SKILL.md', ...}
FAILED (failures=1)
```

느슨해진 게 아니라 대상이 정확해졌다.

Made with [Orca](https://github.com/stablyai/orca) 🐋
