### PR TITLE
feat(mobile-web-planner): 화면설계서를 PDF·PPTX 로 내보내는 스크립트 (#118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ python3 -m unittest discover -s skills/<skill>/tests -t skills/<skill>/tests -v
 - `skills/mobile-web-planner/scripts/check_badge_alignment.py`: 배지 겹침과 라벨-좌표 순서 역전을 점검하는 보조 스크립트.
 - `skills/mobile-web-planner/scripts/apply_badge_audit.py`: badge-audit 실측 JSON 을 받아 인라인 `top` 을 일괄 반영하고 정적 검증기를 재실행하는 스크립트.
 - `skills/mobile-web-planner/resources/badge-audit.js`: 브라우저에서 실행해 배지가 실제로 무엇을 가리키는지 실측하는 스니펫. 목업이 0.9배로 축소되어 인라인 `top` 만으로는 정렬을 알 수 없다.
+- `skills/mobile-web-planner/scripts/export_deck.py`: 산출물 HTML 에서 PDF 와 PPTX 를 함께 만드는 내보내기 스크립트.
 
 ### 클래스 계약 (가장 중요)
 
@@ -100,6 +101,14 @@ python3 skills/mobile-web-planner/scripts/check_badge_alignment.py <생성된파
 ```
 
 셋 다 exit 0 이어야 완료다. 미정의 클래스가 보고되면 `template.html` 에 정의를 추가하거나 사용을 제거한다.
+
+### 내보내기 (PDF · PPTX)
+
+`export_deck.py` 는 두 형식을 **다른 경로로** 만든다 — PDF 는 인쇄 CSS + `--print-to-pdf`(텍스트 벡터), PPTX 는 슬라이드별 PNG + OOXML 조립(텍스트 이미지). 같은 HTML 을 같은 엔진으로 그리므로 내용은 같다. **PDF 를 이미지로 바꾸지 마세요** — 텍스트 선택·검색과 인쇄 선명도를 잃습니다.
+
+pptx 는 `zipfile` 로 직접 조립합니다(이 환경은 stdlib 만 씁니다). 골격은 이미 열리는 것이 확인된 파일과 같아야 하며, `skills/mobile-web-planner/tests/test_export_deck.py` 가 이를 강제합니다.
+
+**관계 타입 URL 을 패키지 네임스페이스에서 파생시키지 마세요.** 둘은 다른 네임스페이스이고, 문자열 조작으로 합치면 `package/2006/officeDocument/2006/...` 같은 무효 URL 이 나옵니다. XML 은 여전히 well-formed 라 파싱 검사로는 안 잡히고 **열 때야 실패합니다** — 실제로 그 버그가 있었습니다.
 
 정적 검사로는 배지가 **의도한 요소를 가리키는지** 알 수 없다 — 목업이 0.9배로 축소되고 콘텐츠 높이가 런타임에 정해지기 때문이다. 브라우저를 쓸 수 있으면 `resources/badge-audit.js` 를 실행해 `misaligned` 가 비어 있는지 확인한다.
 

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -497,24 +497,43 @@ Version: {{VERSION}}
 와 `check_badge_alignment.py` 도 같은 기준이다. 세 검증을 통과하기 전에는 최종
 산출물로 전달하지 않는다.
 
-## A4 인쇄 · PDF 저장
+## PDF · PPTX 내보내기
 
-템플릿에 인쇄 CSS 가 들어 있어 **한 장에 한 슬라이드씩 A4 가로**로 떨어진다. 사용자는
-브라우저에서 열고 인쇄(⌘P) → 대상을 PDF 로 저장하면 된다. 용지·여백·배율을 따로
-만질 필요가 없다 — 문서가 `@page` 로 A4 가로를 지정하고 배율도 스스로 잡는다.
-브라우저 인쇄 대화상자의 **"배경 그래픽"** 옵션만 켜져 있으면 된다(Chrome 은 문서의
-`print-color-adjust` 를 존중하므로 대개 그대로 나온다).
-
-파일에서 바로 뽑아야 하면:
+사용자가 PDF 나 PPT 를 요청하면 `export_deck.py` 를 쓴다. 손으로 Chrome 명령을
+조립하지 않는다.
 
 ```sh
-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless \
-  --virtual-time-budget=15000 --no-pdf-header-footer \
-  --print-to-pdf=<출력.pdf> "file://<절대경로>/<프로젝트명>_storyboard.html"
+python3 <스킬경로>/scripts/export_deck.py <프로젝트명>_storyboard.html
+# -> <프로젝트명>_storyboard.pdf, <프로젝트명>_storyboard.pptx
 ```
 
-`--virtual-time-budget` 은 mermaid 가 렌더될 시간을 준다. 없으면 IA·흐름도·시퀀스
-슬라이드가 **빈 칸으로 인쇄된다.**
+`--pdf-only` / `--pptx-only` 로 하나만 만들 수 있고, `--scale` 로 PPTX 캡처 배율을
+조절한다(기본 2.0 = 2800×1576px, A4 기준 약 240dpi).
+
+**두 형식은 렌더 경로가 다르다 — 의도된 것이다.**
+
+| | 경로 | 텍스트 |
+|---|---|---|
+| PDF | 인쇄 CSS + `--print-to-pdf` | 벡터 · 선택/검색 가능 |
+| PPTX | 슬라이드별 PNG + OOXML 조립 | 이미지 |
+
+같은 HTML 을 같은 렌더 엔진으로 그리므로 내용은 동일하다. **PDF 까지 이미지로
+만들지 않는다** — 텍스트 선택·검색과 인쇄 선명도를 잃는다. 사용자가 "PPT 처럼 똑같이"
+를 요구해도 이 구분은 유지하고 이유를 설명한다.
+
+PPTX 는 슬라이드마다 전면 이미지 한 장이라 **PPT 에서 텍스트를 고칠 수 없다.**
+사용자가 편집을 원하면 HTML 을 고쳐 다시 내보내는 것이 경로다 — 도형·텍스트박스로
+된 PPT 를 만드는 것은 레이아웃을 PPT 오브젝트 모델로 다시 짜는 별개의 작업이다.
+
+### 인쇄 CSS 만 쓸 때
+
+템플릿에 인쇄 CSS 가 들어 있어 브라우저에서 인쇄(⌘P)해도 **한 장에 한 슬라이드씩
+A4 가로**로 떨어진다. 용지·여백·배율을 따로 만질 필요가 없다 — 문서가 `@page` 로
+A4 가로를 지정하고 배율도 스스로 잡는다. 인쇄 대화상자의 **"배경 그래픽"** 옵션만
+켜져 있으면 된다.
+
+headless 로 직접 뽑을 때는 `--virtual-time-budget` 이 mermaid 가 렌더될 시간을
+준다. 없으면 IA·흐름도·시퀀스 슬라이드가 **빈 칸으로 인쇄된다.**
 
 16:9 슬라이드를 A4(1.414)에 넣으면 위아래로 21mm 씩 여백이 남는다. 이건 결함이 아니라
 PPT 덱을 A4 로 뽑을 때의 정상 결과다. 사용자가 "A4 에 꽉 채워 달라" 고 하면 슬라이드

--- a/skills/mobile-web-planner/scripts/export_deck.py
+++ b/skills/mobile-web-planner/scripts/export_deck.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""화면설계서 HTML 하나에서 PDF 와 PPTX 를 함께 만든다.
+
+    python3 export_deck.py <프로젝트명>_storyboard.html
+    # -> <프로젝트명>_storyboard.pdf, <프로젝트명>_storyboard.pptx
+
+두 형식은 렌더 경로가 다르다. 의도된 것이다.
+
+    PDF   인쇄 CSS + Chrome --print-to-pdf   텍스트가 벡터라 선택·검색된다
+    PPTX  슬라이드별 PNG + OOXML 조립        텍스트가 이미지다
+
+같은 HTML 을 같은 렌더 엔진으로 그리므로 내용은 동일하다. PDF 까지 이미지로
+만들면 텍스트 선택·검색과 인쇄 선명도를 잃으므로 그렇게 하지 않는다.
+
+PPT 를 편집 가능한 도형·텍스트로 만드는 것은 HTML/CSS 레이아웃을 PPT 오브젝트
+모델로 다시 짜는 별개의 작업이며 이 스크립트의 범위가 아니다.
+
+stdlib 만 쓴다 — 이 저장소의 검증·생성 스크립트 공통 규약이다.
+"""
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+# 슬라이드 설계 기준. 목업 크기와 배지 인라인 top 이 전부 이 폭에서 나온
+# 절대 픽셀값이라, 다른 폭으로 렌더하면 목업이 넘치거나 배지가 어긋난다.
+DESIGN_W, DESIGN_H = 1400, 788
+
+# PPTX 슬라이드 크기 (EMU). 16:9 와이드스크린 = 13.333 x 7.5 inch.
+EMU_W, EMU_H = 12192000, 6858000
+
+# mermaid 는 JS 렌더다. 이 시간을 주지 않으면 IA·흐름도·시퀀스 슬라이드가
+# 빈 칸으로 캡처·인쇄된다.
+RENDER_WAIT_MS = 15000
+
+CHROME_CANDIDATES = (
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+)
+
+XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+NS_A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+CT_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+# 관계 타입의 네임스페이스는 패키지 네임스페이스(REL_NS)와 다르다. 둘을 문자열
+# 조작으로 파생시키면 package/2006/officeDocument/2006/... 같은 무효 URL 이 나오는데,
+# XML 은 여전히 well-formed 라 파싱 검사로는 잡히지 않는다 — 열 때야 실패한다.
+REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def find_chrome(explicit=None):
+    """Chrome 실행 파일을 찾는다. 경로를 하드코딩하지 않는다."""
+    for cand in filter(None, (explicit, os.environ.get("CHROME"), *CHROME_CANDIDATES)):
+        found = cand if os.path.isfile(cand) else shutil.which(cand)
+        if found:
+            return found
+    sys.exit(
+        "오류: Chrome 을 찾을 수 없다. --chrome 으로 경로를 주거나 CHROME 환경변수를 "
+        "설정할 것 (macOS 는 'Google Chrome.app', 리눅스는 google-chrome/chromium)"
+    )
+
+
+def run_chrome(chrome, *args):
+    result = subprocess.run(
+        [chrome, "--headless", "--disable-gpu", "--hide-scrollbars",
+         f"--virtual-time-budget={RENDER_WAIT_MS}", *args],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"오류: Chrome 실행 실패 (exit {result.returncode})\n{result.stderr[-600:]}")
+
+
+def split_slides(html):
+    """`<div class="ppt-slide">` 블록을 문서 순서대로 잘라낸다.
+
+    반환값은 (슬라이드 번호, 블록 HTML) 목록. 파서를 쓰지 않고 div 깊이를
+    세는 이유는 stdlib 의 HTMLParser 로 원문을 그대로 되돌리기 어려워서다 —
+    인라인 style 과 SVG 가 많은 문서라 재직렬화하면 렌더가 달라진다.
+    """
+    slides = []
+    tag = re.compile(r"<div\b|</div>")
+    for match in re.finditer(r'<div class="ppt-slide">', html):
+        depth, cursor = 0, match.start()
+        while cursor < len(html):
+            found = tag.search(html, cursor)
+            if not found:
+                break
+            depth += 1 if found.group() != "</div>" else -1
+            cursor = found.end()
+            if depth == 0:
+                break
+        block = html[match.start():cursor]
+        no = re.search(r'class="ppt-top-no">NO\.\s*([\d.]+)<', block)
+        slides.append((no.group(1) if no else str(len(slides) + 1), block))
+    return slides
+
+
+def isolated_page(head, block, ordinal):
+    """슬라이드 하나만 담은 문서. 캡처 크기를 슬라이드에 정확히 맞춘다.
+
+    Page No. 는 CSS counter 라 슬라이드를 떼어내면 1부터 다시 센다.
+    counter-reset 으로 원본 순번을 유지한다.
+    """
+    return (
+        f'{head}<body style="margin:0;padding:0;background:#fff;">'
+        f'<div class="docwrap" style="max-width:none;gap:0;'
+        f'counter-reset:slide {ordinal};">{block}</div></body></html>'
+    )
+
+
+def export_pdf(chrome, src, dest):
+    """인쇄 CSS 를 그대로 태워 A4 가로 PDF 를 만든다."""
+    run_chrome(chrome, "--no-pdf-header-footer",
+               f"--print-to-pdf={dest}", f"file://{src.resolve()}")
+    if not dest.is_file():
+        sys.exit(f"오류: PDF 가 생성되지 않았다 — {dest}")
+    return dest
+
+
+def shoot_slides(chrome, head, slides, workdir, scale):
+    """슬라이드마다 PNG 를 뜬다."""
+    page = workdir / "_slide.html"
+    shots = []
+    for index, (_, block) in enumerate(slides):
+        page.write_text(isolated_page(head, block, index), encoding="utf-8")
+        shot = workdir / f"image{index + 1}.png"
+        run_chrome(chrome,
+                   f"--window-size={DESIGN_W},{DESIGN_H}",
+                   f"--force-device-scale-factor={scale}",
+                   f"--screenshot={shot}", f"file://{page.resolve()}")
+        if not shot.is_file():
+            sys.exit(f"오류: 슬라이드 {index + 1} 캡처 실패")
+        shots.append(shot)
+    page.unlink(missing_ok=True)
+    return shots
+
+
+def _rels(entries):
+    body = "".join(
+        f'<Relationship Id="{rid}" Type="{REL_TYPE}/{kind}" Target="{target}"/>'
+        for rid, kind, target in entries
+    )
+    return f'{XML_DECL}<Relationships xmlns="{REL_NS}">{body}</Relationships>'
+
+
+def build_pptx(shots, dest):
+    """PNG 목록으로 최소 구조의 pptx 를 조립한다.
+
+    골격은 PowerPoint·Keynote·LibreOffice 가 여는 최소 집합이다 — 마스터 1개,
+    빈 레이아웃 1개, 테마 1개, 슬라이드마다 전면 이미지 1개.
+    """
+    count = len(shots)
+    grp = ('<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>'
+           '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>'
+           '<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>')
+
+    content_types = (
+        f'{XML_DECL}<Types xmlns="{CT_NS}">'
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        '<Default Extension="xml" ContentType="application/xml"/>'
+        '<Default Extension="png" ContentType="image/png"/>'
+        '<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>'
+        '<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>'
+        '<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>'
+        '<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>'
+        + "".join(
+            f'<Override PartName="/ppt/slides/slide{i}.xml" '
+            'ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>'
+            for i in range(1, count + 1))
+        + "</Types>")
+
+    slide_ids = "".join(
+        f'<p:sldId id="{255 + i}" r:id="rId{i + 1}"/>' for i in range(1, count + 1))
+    presentation = (
+        f'{XML_DECL}<p:presentation xmlns:a="{NS_A}" xmlns:r="{NS_R}" xmlns:p="{NS_P}">'
+        '<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>'
+        f'<p:sldIdLst>{slide_ids}</p:sldIdLst>'
+        f'<p:sldSz cx="{EMU_W}" cy="{EMU_H}"/>'
+        f'<p:notesSz cx="{EMU_H}" cy="{EMU_W}"/></p:presentation>')
+
+    presentation_rels = _rels(
+        [("rId1", "slideMaster", "slideMasters/slideMaster1.xml")]
+        + [(f"rId{i + 1}", "slide", f"slides/slide{i}.xml") for i in range(1, count + 1)])
+
+    master = (
+        f'{XML_DECL}<p:sldMaster xmlns:a="{NS_A}" xmlns:r="{NS_R}" xmlns:p="{NS_P}">'
+        '<p:cSld><p:bg><p:bgPr><a:solidFill><a:schemeClr val="lt1"/></a:solidFill>'
+        f'<a:effectLst/></p:bgPr></p:bg><p:spTree>{grp}</p:spTree></p:cSld>'
+        '<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" '
+        'accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" '
+        'accent6="accent6" hlink="hlink" folHlink="folHlink"/>'
+        '<p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst>'
+        '</p:sldMaster>')
+
+    layout = (
+        f'{XML_DECL}<p:sldLayout xmlns:a="{NS_A}" xmlns:r="{NS_R}" xmlns:p="{NS_P}" type="blank">'
+        f'<p:cSld name="Blank"><p:spTree>{grp}</p:spTree></p:cSld>'
+        '<p:clrMapOvr><a:overrideClrMapping bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" '
+        'accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" '
+        'accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>'
+        '</p:clrMapOvr></p:sldLayout>')
+
+    theme = (
+        f'{XML_DECL}<a:theme xmlns:a="{NS_A}" name="Theme"><a:themeElements>'
+        '<a:clrScheme name="Office">'
+        '<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>'
+        '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>'
+        '<a:dk2><a:srgbClr val="1E2A5C"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>'
+        '<a:accent1><a:srgbClr val="1B64DA"/></a:accent1><a:accent2><a:srgbClr val="0F9D58"/></a:accent2>'
+        '<a:accent3><a:srgbClr val="F59E0B"/></a:accent3><a:accent4><a:srgbClr val="E5484D"/></a:accent4>'
+        '<a:accent5><a:srgbClr val="7C3AED"/></a:accent5><a:accent6><a:srgbClr val="94A3B8"/></a:accent6>'
+        '<a:hlink><a:srgbClr val="1B64DA"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink>'
+        '</a:clrScheme><a:fontScheme name="Office">'
+        '<a:majorFont><a:latin typeface="Calibri"/><a:ea typeface="Apple SD Gothic Neo"/><a:cs typeface=""/></a:majorFont>'
+        '<a:minorFont><a:latin typeface="Calibri"/><a:ea typeface="Apple SD Gothic Neo"/><a:cs typeface=""/></a:minorFont>'
+        '</a:fontScheme><a:fmtScheme name="Office">'
+        '<a:fillStyleLst>' + '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' * 3 + '</a:fillStyleLst>'
+        '<a:lnStyleLst>' + "".join(
+            f'<a:ln w="{w}"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>'
+            for w in (6350, 12700, 19050)) + '</a:lnStyleLst>'
+        '<a:effectStyleLst>' + '<a:effectStyle><a:effectLst/></a:effectStyle>' * 3 + '</a:effectStyleLst>'
+        '<a:bgFillStyleLst>' + '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' * 3 + '</a:bgFillStyleLst>'
+        '</a:fmtScheme></a:themeElements></a:theme>')
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as pkg:
+        pkg.writestr("[Content_Types].xml", content_types)
+        pkg.writestr("_rels/.rels", _rels([("rId1", "officeDocument", "ppt/presentation.xml")]))
+        pkg.writestr("ppt/presentation.xml", presentation)
+        pkg.writestr("ppt/_rels/presentation.xml.rels", presentation_rels)
+        pkg.writestr("ppt/theme/theme1.xml", theme)
+        pkg.writestr("ppt/slideMasters/slideMaster1.xml", master)
+        pkg.writestr("ppt/slideMasters/_rels/slideMaster1.xml.rels", _rels([
+            ("rId1", "slideLayout", "../slideLayouts/slideLayout1.xml"),
+            ("rId2", "theme", "../theme/theme1.xml")]))
+        pkg.writestr("ppt/slideLayouts/slideLayout1.xml", layout)
+        pkg.writestr("ppt/slideLayouts/_rels/slideLayout1.xml.rels", _rels([
+            ("rId1", "slideMaster", "../slideMasters/slideMaster1.xml")]))
+        for i, shot in enumerate(shots, start=1):
+            pkg.writestr(f"ppt/slides/slide{i}.xml",
+                         f'{XML_DECL}<p:sld xmlns:a="{NS_A}" xmlns:r="{NS_R}" xmlns:p="{NS_P}">'
+                         f'<p:cSld><p:spTree>{grp}'
+                         f'<p:pic><p:nvPicPr><p:cNvPr id="2" name="Slide Image {i}"/>'
+                         '<p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr>'
+                         '<p:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>'
+                         f'<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="{EMU_W}" cy="{EMU_H}"/></a:xfrm>'
+                         '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>'
+                         '</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>')
+            pkg.writestr(f"ppt/slides/_rels/slide{i}.xml.rels", _rels([
+                ("rId1", "slideLayout", "../slideLayouts/slideLayout1.xml"),
+                ("rId2", "image", f"../media/image{i}.png")]))
+            pkg.write(shot, f"ppt/media/image{i}.png")
+    return dest
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="화면설계서 HTML 에서 PDF 와 PPTX 를 만든다")
+    parser.add_argument("storyboard", help="<프로젝트명>_storyboard.html")
+    parser.add_argument("--outdir", help="출력 디렉터리 (기본: 입력과 같은 곳)")
+    parser.add_argument("--pdf-only", action="store_true")
+    parser.add_argument("--pptx-only", action="store_true")
+    parser.add_argument("--scale", type=float, default=2.0,
+                        help="PPTX 캡처 배율 (기본 2.0 = 2800x1576px, A4 기준 약 240dpi)")
+    parser.add_argument("--chrome", help="Chrome 실행 파일 경로")
+    args = parser.parse_args()
+
+    if args.pdf_only and args.pptx_only:
+        sys.exit("오류: --pdf-only 와 --pptx-only 는 함께 쓸 수 없다")
+
+    src = Path(args.storyboard)
+    if not src.is_file():
+        sys.exit(f"오류: 파일이 없다 — {src}")
+    outdir = Path(args.outdir) if args.outdir else src.parent
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    html = src.read_text(encoding="utf-8")
+    if "<body>" not in html:
+        sys.exit("오류: <body> 가 없다 — 화면설계서 산출물이 맞는지 확인할 것")
+    chrome = find_chrome(args.chrome)
+    made = []
+
+    if not args.pptx_only:
+        pdf = export_pdf(chrome, src, outdir / f"{src.stem}.pdf")
+        made.append(pdf)
+
+    if not args.pdf_only:
+        slides = split_slides(html)
+        if not slides:
+            sys.exit("오류: ppt-slide 를 찾을 수 없다")
+        head = html[:html.index("<body>")]
+        with tempfile.TemporaryDirectory() as tmp:
+            shots = shoot_slides(chrome, head, slides, Path(tmp), args.scale)
+            pptx = build_pptx(shots, outdir / f"{src.stem}.pptx")
+        made.append(pptx)
+        print(f"슬라이드 {len(slides)}장 캡처 (배율 {args.scale})")
+
+    for path in made:
+        print(f"생성: {path}  ({path.stat().st_size // 1024:,}KB)")
+    if len(made) == 2:
+        print("PDF 는 텍스트가 벡터라 선택·검색된다. PPTX 는 슬라이드별 이미지다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mobile-web-planner/scripts/export_deck.py
+++ b/skills/mobile-web-planner/scripts/export_deck.py
@@ -119,10 +119,54 @@ def isolated_page(head, block, ordinal):
     )
 
 
-def export_pdf(chrome, src, dest):
-    """인쇄 CSS 를 그대로 태워 A4 가로 PDF 를 만든다."""
+# 인쇄 CSS 블록의 시작 표식. 템플릿 안에서 이 주석부터 </style> 까지가
+# @page 와 @media print 규칙이다.
+PRINT_CSS_MARKER = "인쇄 · PDF 저장 (A4 가로"
+
+
+def template_print_css():
+    """템플릿에서 인쇄 CSS 블록을 떼어 온다.
+
+    인쇄 CSS 의 원본은 resources/template.html 한 곳이다. 여기에 복제해 두면
+    템플릿이 바뀔 때 조용히 어긋난다.
+    """
+    template = Path(__file__).resolve().parent.parent / "resources" / "template.html"
+    if not template.is_file():
+        return None
+    text = template.read_text(encoding="utf-8")
+    start = text.find(PRINT_CSS_MARKER)
+    end = text.find("</style>", start)
+    if start == -1 or end == -1:
+        return None
+    # 주석 여는 기호까지 포함되도록 앞으로 되짚는다
+    start = text.rfind("/*", 0, start)
+    return text[start:end]
+
+
+def export_pdf(chrome, src, dest, workdir):
+    """인쇄 CSS 를 태워 A4 가로 PDF 를 만든다.
+
+    인쇄 CSS 가 없는 예전 산출물이면 템플릿의 것을 임시 사본에 주입해 쓴다.
+    그러지 않으면 기본 용지(US Letter 세로)로 떨어지고 슬라이드가 페이지
+    경계에서 잘린 PDF 가 조용히 나온다 — 46슬라이드 문서가 20페이지로 나온
+    실측 사례가 있다. 사용자의 원본 파일은 건드리지 않는다.
+    """
+    source = src
+    if "@media print" not in src.read_text(encoding="utf-8"):
+        css = template_print_css()
+        if css is None:
+            print("경고: 인쇄 CSS 가 없고 템플릿에서도 찾지 못했다 — "
+                  "PDF 가 기본 용지로 떨어진다", file=sys.stderr)
+        else:
+            patched = workdir / f"{src.stem}_print.html"
+            patched.write_text(
+                src.read_text(encoding="utf-8").replace("</style>", css + "</style>", 1),
+                encoding="utf-8")
+            source = patched
+            print("알림: 인쇄 CSS 가 없는 산출물이라 템플릿의 것을 주입해 PDF 를 만든다 "
+                  "(원본 파일은 바꾸지 않는다)")
     run_chrome(chrome, "--no-pdf-header-footer",
-               f"--print-to-pdf={dest}", f"file://{src.resolve()}")
+               f"--print-to-pdf={dest}", f"file://{source.resolve()}")
     if not dest.is_file():
         sys.exit(f"오류: PDF 가 생성되지 않았다 — {dest}")
     return dest
@@ -290,20 +334,19 @@ def main():
     chrome = find_chrome(args.chrome)
     made = []
 
-    if not args.pptx_only:
-        pdf = export_pdf(chrome, src, outdir / f"{src.stem}.pdf")
-        made.append(pdf)
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        if not args.pptx_only:
+            made.append(export_pdf(chrome, src, outdir / f"{src.stem}.pdf", work))
 
-    if not args.pdf_only:
-        slides = split_slides(html)
-        if not slides:
-            sys.exit("오류: ppt-slide 를 찾을 수 없다")
-        head = html[:html.index("<body>")]
-        with tempfile.TemporaryDirectory() as tmp:
-            shots = shoot_slides(chrome, head, slides, Path(tmp), args.scale)
-            pptx = build_pptx(shots, outdir / f"{src.stem}.pptx")
-        made.append(pptx)
-        print(f"슬라이드 {len(slides)}장 캡처 (배율 {args.scale})")
+        if not args.pdf_only:
+            slides = split_slides(html)
+            if not slides:
+                sys.exit("오류: ppt-slide 를 찾을 수 없다")
+            head = html[:html.index("<body>")]
+            shots = shoot_slides(chrome, head, slides, work, args.scale)
+            made.append(build_pptx(shots, outdir / f"{src.stem}.pptx"))
+            print(f"슬라이드 {len(slides)}장 캡처 (배율 {args.scale})")
 
     for path in made:
         print(f"생성: {path}  ({path.stat().st_size // 1024:,}KB)")

--- a/skills/mobile-web-planner/tests/test_export_deck.py
+++ b/skills/mobile-web-planner/tests/test_export_deck.py
@@ -132,6 +132,36 @@ class TestPptxPackage(unittest.TestCase):
         self.assertIn(f'<a:ext cx="{export_deck.EMU_W}" cy="{export_deck.EMU_H}"/>', slide)
 
 
+class TestPrintCssFallback(unittest.TestCase):
+    """인쇄 CSS 가 없는 예전 산출물도 A4 로 떨어져야 한다.
+
+    #114 이전에 만든 문서에는 @page 가 없다. 그대로 인쇄하면 기본 용지(US
+    Letter 세로)로 떨어지고 슬라이드가 페이지 경계에서 잘린다 — 46슬라이드
+    문서가 20페이지로 나온 실측 사례가 있다.
+    """
+
+    def test_template_still_exposes_the_print_block(self):
+        css = export_deck.template_print_css()
+        self.assertIsNotNone(css, "템플릿에서 인쇄 CSS 를 찾지 못했다 — 표식이 바뀌었나")
+        self.assertIn("@page", css)
+        self.assertIn("size: A4 landscape", css)
+        self.assertIn("@media print", css)
+
+    def test_injected_css_lands_inside_the_style_block(self):
+        css = export_deck.template_print_css()
+        legacy = storyboard(2)
+        self.assertNotIn("@media print", legacy)
+        patched = legacy.replace("</style>", css + "</style>", 1)
+        self.assertIn("@media print", patched)
+        # 스타일 블록 안에 들어가야 유효하다
+        self.assertLess(patched.index("@page"), patched.index("</style>"))
+
+    def test_print_css_is_not_duplicated_in_the_script(self):
+        """인쇄 CSS 의 원본은 템플릿 한 곳이다."""
+        source = (SKILL_ROOT / "scripts" / "export_deck.py").read_text(encoding="utf-8")
+        self.assertNotIn("size: A4 landscape", source)
+
+
 class TestDesignConstants(unittest.TestCase):
     def test_capture_width_matches_the_template_design_width(self):
         """목업 크기와 배지 top 이 이 폭에서 나온 절대 픽셀값이다."""

--- a/skills/mobile-web-planner/tests/test_export_deck.py
+++ b/skills/mobile-web-planner/tests/test_export_deck.py
@@ -1,0 +1,147 @@
+"""export_deck.py 의 PPTX 조립 계약을 검증한다 (stdlib only).
+
+Chrome 을 띄우는 부분은 이 테스트의 대상이 아니다 — 캡처는 환경에 의존하고
+느리다. 대신 순수 함수인 슬라이드 분해와 OOXML 조립을 검증한다.
+"""
+import re
+import sys
+import unittest
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+import export_deck  # noqa: E402
+
+
+PNG_1PX = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6360000002000100" "05fe02fe" "dccc59e7"
+    "0000000049454e44ae426082"
+)
+
+
+def storyboard(slide_count):
+    slides = "".join(
+        f'<div class="ppt-slide"><div class="ppt-top-bar">'
+        f'<div class="ppt-top-no">NO. {i:02d}</div></div>'
+        f'<div class="ppt-content"><div class="ppt-body-full">본문 {i}</div></div>'
+        f'</div>'
+        for i in range(1, slide_count + 1)
+    )
+    return (f'<html><head><style>.x{{}}</style></head><body>'
+            f'<div class="docwrap">{slides}</div></body></html>')
+
+
+class TestSlideSplit(unittest.TestCase):
+    def test_splits_every_slide_in_document_order(self):
+        slides = export_deck.split_slides(storyboard(4))
+        self.assertEqual([no for no, _ in slides], ["01", "02", "03", "04"])
+
+    def test_keeps_nested_divs_intact(self):
+        _, block = export_deck.split_slides(storyboard(1))[0]
+        self.assertIn("ppt-body-full", block)
+        self.assertTrue(block.endswith("</div>"))
+        # 여는 div 와 닫는 div 수가 같아야 블록이 온전하다
+        self.assertEqual(len(re.findall(r"<div\b", block)),
+                         len(re.findall(r"</div>", block)))
+
+    def test_isolated_page_preserves_original_page_number(self):
+        """Page No. 는 CSS counter 라 떼어내면 1부터 다시 센다."""
+        page = export_deck.isolated_page("<html><head></head>", "<div/>", 14)
+        self.assertIn("counter-reset:slide 14", page)
+
+
+class TestPptxPackage(unittest.TestCase):
+    def _build(self, count):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        shots = []
+        for i in range(1, count + 1):
+            shot = root / f"image{i}.png"
+            shot.write_bytes(PNG_1PX)
+            shots.append(shot)
+        dest = root / "deck.pptx"
+        export_deck.build_pptx(shots, dest)
+        return zipfile.ZipFile(dest)
+
+    def test_relationship_types_use_the_officedocument_namespace(self):
+        """관계 타입 URL 은 패키지 네임스페이스에서 파생시킬 수 없다.
+
+        둘을 문자열 조작으로 합치면 package/2006/officeDocument/2006/... 같은
+        무효 URL 이 나오는데 XML 은 여전히 well-formed 라 파싱 검사로는 잡히지
+        않는다. 실제로 그 버그가 있었고, 파일은 열리지 않는다.
+        """
+        pkg = self._build(2)
+        for name in pkg.namelist():
+            if not name.endswith(".rels"):
+                continue
+            for url in re.findall(r'Type="([^"]+)"', pkg.read(name).decode()):
+                with self.subTest(part=name, url=url):
+                    self.assertTrue(
+                        url.startswith(
+                            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/"),
+                        f"관계 타입 URL 이 잘못됐다: {url}")
+
+    def test_every_part_is_wellformed_xml(self):
+        pkg = self._build(3)
+        for name in pkg.namelist():
+            if name.endswith((".xml", ".rels")):
+                with self.subTest(part=name):
+                    ET.fromstring(pkg.read(name))
+
+    def test_content_types_declares_every_slide(self):
+        pkg = self._build(5)
+        declared = pkg.read("[Content_Types].xml").decode()
+        for i in range(1, 6):
+            with self.subTest(slide=i):
+                self.assertIn(f'PartName="/ppt/slides/slide{i}.xml"', declared)
+
+    def test_each_slide_references_an_image_that_exists(self):
+        pkg = self._build(4)
+        names = set(pkg.namelist())
+        for i in range(1, 5):
+            rels = pkg.read(f"ppt/slides/_rels/slide{i}.xml.rels").decode()
+            targets = re.findall(r'Target="\.\./media/([^"]+)"', rels)
+            with self.subTest(slide=i):
+                self.assertEqual(len(targets), 1)
+                self.assertIn(f"ppt/media/{targets[0]}", names)
+
+    def test_presentation_lists_every_slide_with_matching_rels(self):
+        pkg = self._build(6)
+        pres = pkg.read("ppt/presentation.xml").decode()
+        rels = pkg.read("ppt/_rels/presentation.xml.rels").decode()
+        rids = re.findall(r'<p:sldId id="\d+" r:id="(rId\d+)"/>', pres)
+        self.assertEqual(len(rids), 6)
+        for rid in rids:
+            with self.subTest(rid=rid):
+                self.assertRegex(rels, f'Id="{rid}"[^>]*Target="slides/slide\\d+\\.xml"')
+
+    def test_slide_size_is_16_by_9_widescreen(self):
+        pres = self._build(1).read("ppt/presentation.xml").decode()
+        self.assertIn(f'<p:sldSz cx="{export_deck.EMU_W}" cy="{export_deck.EMU_H}"/>', pres)
+        self.assertAlmostEqual(export_deck.EMU_W / export_deck.EMU_H, 16 / 9, places=3)
+
+    def test_image_fills_the_whole_slide(self):
+        slide = self._build(1).read("ppt/slides/slide1.xml").decode()
+        self.assertIn('<a:off x="0" y="0"/>', slide)
+        self.assertIn(f'<a:ext cx="{export_deck.EMU_W}" cy="{export_deck.EMU_H}"/>', slide)
+
+
+class TestDesignConstants(unittest.TestCase):
+    def test_capture_width_matches_the_template_design_width(self):
+        """목업 크기와 배지 top 이 이 폭에서 나온 절대 픽셀값이다."""
+        template = (SKILL_ROOT / "resources" / "template.html").read_text(encoding="utf-8")
+        self.assertIn(f"max-width: {export_deck.DESIGN_W}px", template)
+
+    def test_render_wait_is_long_enough_for_mermaid(self):
+        """대기가 없으면 IA·흐름도·시퀀스가 빈 칸으로 나온다."""
+        self.assertGreaterEqual(export_deck.RENDER_WAIT_MS, 5000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #118

화면설계서 HTML 하나에서 PDF 와 PPTX 를 함께 만든다.

```bash
python3 <스킬경로>/scripts/export_deck.py <프로젝트명>_storyboard.html
# → <프로젝트명>_storyboard.pdf, <프로젝트명>_storyboard.pptx
```

`--pdf-only` / `--pptx-only` / `--scale` / `--chrome` 지원. Chrome 경로는 하드코딩하지 않고 `--chrome` → `CHROME` 환경변수 → 흔한 설치 경로 순으로 찾는다.

## 두 형식의 렌더 경로가 다르다 — 의도된 것이다

| | 경로 | 텍스트 |
|---|---|---|
| PDF | 인쇄 CSS + `--print-to-pdf` | 벡터 · 선택/검색 가능 |
| PPTX | 슬라이드별 PNG + OOXML 조립 | 이미지 |

같은 HTML 을 같은 렌더 엔진으로 그리므로 **내용은 동일**하다. PDF 까지 이미지로 만들면 텍스트 선택·검색과 인쇄 선명도를 잃으므로 그렇게 하지 않았다. SKILL.md 에 "사용자가 똑같이 만들어 달라고 해도 이 구분은 유지하고 이유를 설명한다" 로 적었다.

PPTX 는 슬라이드마다 전면 이미지 한 장이라 **PPT 에서 텍스트를 고칠 수 없다.** 편집 가능한 도형·텍스트 PPT 는 레이아웃을 PPT 오브젝트 모델로 다시 짜는 별개 작업이라 범위 밖으로 뒀다.

## 조립

`python-pptx` 를 쓸 수 없다 — 이 환경의 Homebrew Python 은 외부 라이브러리 import 가 깨져 있고, 저장소 규약도 stdlib 만이다. pptx 는 zip + XML 이므로 `zipfile` 로 직접 조립했다.

골격은 이미 열리는 것이 확인된 기존 pptx 와 같게 맞췄고, **골격 8개 파트가 바이트 단위로 일치**하는 것을 확인했다.

## 잡은 결함 하나 — 이게 이 PR 의 핵심

관계 타입 URL 을 패키지 네임스페이스에서 `rsplit` 으로 파생시켰다.

```
생성: .../package/2006/officeDocument/2006/relationships/officeDocument   ← 무효
기준: .../officeDocument/2006/relationships/officeDocument
```

**XML 은 여전히 well-formed 라 파싱 검사를 통과했다.** zip 무결성·XML 파싱·참조 무결성 검사를 다 통과하고도 파일은 열리지 않는 상태였다. 정상 파일과 바이트 비교를 하지 않았으면 "검증 통과" 로 넘어갔을 것이다.

`test_export_deck.py` 가 이 URL 형식을 검사한다. 버그를 되살려 **11건이 실패**하고 복구 후 통과하는 것을 둘 다 확인했다.

## 확인 — 25슬라이드 실산출물

```
PDF   2,143KB
PPTX  5,155KB   2800x1576px (A4 가로 기준 239dpi)

zip 무결성 OK · XML 파싱 실패 없음 · 끊어진 이미지 참조 없음
슬라이드 25장 전부 Content_Types 선언 · 골격 8개 파트 기존 파일과 일치
./scripts/run_tests.sh 전부 통과 (mobile-web-planner 140 → 152)
```

## 남은 것

기존 `output/금융지킴이_storyboard.pptx` 는 화면 상세의 Description 패널이 **텍스트박스로** 올라가 있었다. 이 스크립트는 전부 이미지라 그 부분은 재현하지 않는다. 설명 텍스트만 선택·편집 가능하게 얹는 것은 좌표 측정이 필요한 별도 작업이라 분리한다.

---

## 추가 — 46슬라이드 실산출물 시험에서 결함 하나 더 잡음

`output/금융지킴이_storyboard.html` (46슬라이드, #114 이전 생성이라 `@page` 없음)로 시험했다.

**PDF 가 조용히 깨졌다.**

```
20페이지 (슬라이드 46장) / 215.9 x 279.4mm = US Letter 세로
```

기본 용지로 떨어지고 슬라이드가 페이지 경계에서 잘렸는데, 스크립트는 아무 말 없이 성공으로 끝났다. 파일을 열어보기 전에는 알 수 없는 실패였다.

**고침** — 인쇄 CSS 가 없으면 템플릿의 것을 임시 사본에 주입한다. 원본 파일은 건드리지 않고 주입 사실을 알린다.

```
46페이지 (슬라이드 46장) / 297.0 x 209.9mm = A4 가로   ← 원본 파일 그대로
```

인쇄 CSS 의 원본은 `resources/template.html` 한 곳이라 스크립트에 복제하지 않고 떼어 온다. 테스트가 스크립트 안에 `size: A4 landscape` 가 **없는 것**까지 검사한다.

**PPTX 는 이상 없었다.** 46슬라이드/46이미지 정상. 기존 정상 파일과 비교하면:

| | 결과 |
|---|---|
| 파트 이름 집합 | 완전 일치 |
| 골격 XML (마스터·레이아웃·테마·rels·Content_Types) | **전부 바이트 일치** |
| 배지 없는 슬라이드 13장 | **바이트 일치** |
| 배지 있는 슬라이드 33장 | 기준 파일에만 `<p:sp name="badge 1-1">` 도형과 설명 텍스트가 더 있음 |

마지막 줄이 위에 적은 "남은 것"의 정확한 범위다 — 기존 파일은 Description 텍스트뿐 아니라 **배지 칩도 PPT 도형**으로 얹혀 있었다.

테스트 12 → 15개.
