### PR TITLE
feat(mobile-web-planner): Chrome 기반 레이아웃 회귀 검사 (#137)

### DIFF
--- a/.github/workflows/layout.yml
+++ b/.github/workflows/layout.yml
@@ -1,0 +1,37 @@
+# 브라우저가 필요한 레이아웃 회귀 검사만 따로 돌린다 (이슈 #137).
+#
+# 기존 test.yml 은 stdlib 만 쓰는 저장소 전체 테스트라 Chrome 이 없어도
+# 끝까지 돈다 — 그 잡에 브라우저를 끌어들이면 스킬 하나 때문에 전체
+# 파이프라인이 러너의 Chrome 버전에 묶인다. 그래서 잡을 분리했다.
+#
+# 판정 대상은 픽셀이 아니라 구조·좌표다(슬라이드 overflow · 배지 이탈/겹침 ·
+# 설명 패널 잘림). 렌더는 외부 폰트와 mermaid CDN 을 떼고 오프라인으로 한다.
+name: layout
+
+on:
+  pull_request:
+    paths:
+      - "skills/mobile-web-planner/**"
+      - ".github/workflows/layout.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/mobile-web-planner/**"
+      - ".github/workflows/layout.yml"
+
+jobs:
+  layout:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show Chrome version
+        run: google-chrome --version
+      - name: Render baseline and check layout contracts
+        env:
+          CHROME: google-chrome
+        run: |
+          python3 -m unittest discover \
+            -s skills/mobile-web-planner/tests \
+            -t skills/mobile-web-planner/tests \
+            -p test_layout_runtime.py -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ python3 -m unittest discover -s skills/<skill>/tests -t skills/<skill>/tests -v
 - `skills/mobile-web-planner/scripts/apply_badge_audit.py`: badge-audit 실측 JSON 을 받아 인라인 `top` 을 일괄 반영하고 정적 검증기를 재실행하는 스크립트.
 - `skills/mobile-web-planner/resources/badge-audit.js`: 브라우저에서 실행해 배지가 실제로 무엇을 가리키는지 실측하는 스니펫. 목업이 0.9배로 축소되어 인라인 `top` 만으로는 정렬을 알 수 없다.
 - `skills/mobile-web-planner/scripts/export_deck.py`: 산출물 HTML 에서 PDF 와 PPTX 를 함께 만드는 내보내기 스크립트.
+- `skills/mobile-web-planner/scripts/check_layout_runtime.py`: Chrome headless 로 렌더해 레이아웃 회귀(슬라이드 overflow · 배지 이탈/겹침 · 설명 패널 잘림)를 잡는 검사기.
+- `skills/mobile-web-planner/resources/layout-probe.js`: 위 검사기가 주입하는 좌표 수집 스니펫. **판정은 하지 않는다** — 임계값은 파이썬 한 곳에만 둔다.
 
 ### 클래스 계약 (가장 중요)
 
@@ -105,6 +107,31 @@ python3 skills/mobile-web-planner/scripts/check_badge_alignment.py <생성된파
 ```
 
 셋 다 exit 0 이어야 완료다. 미정의 클래스가 보고되면 `template.html` 에 정의를 추가하거나 사용을 제거한다.
+
+### 레이아웃 회귀 검사 (브라우저)
+
+```bash
+python3 skills/mobile-web-planner/scripts/check_layout_runtime.py <생성된파일.html>
+```
+
+정적 검사기는 마크업의 인라인 좌표만 본다. 템플릿 CSS 가 바뀌어 목업 높이·gutter·설명
+패널 밀도가 달라지면 마크업은 그대로인데 결과만 깨진다 — 그건 렌더해야 보인다. 실제로
+이 검사기가 `.mock-footer` 에 `position: relative` 가 없어 푸터 배지가 `.mock` 기준으로
+떠 있던 것을 잡았다(이슈 #71 은 헤더만 고쳤다).
+
+- 판정은 **구조·좌표**다. 전체 픽셀 비교는 브라우저·폰트 버전이 바뀔 때마다 false
+  positive 를 내므로 도입하지 않는다. 필요해지면 허용 오차가 있는 부분 비교를 나중에 얹는다.
+- 렌더는 기본이 **오프라인**이다(외부 폰트 `@import` 와 mermaid CDN 제거). 러너의 네트워크
+  상태가 판정을 흔들면 회귀 검사가 아니다. mermaid 슬라이드는 overflow 판정에서 빠지며 그
+  사실이 출력에 찍힌다.
+- 렌더 폭은 설계 기준 `DESIGN_W`(1400px)로 고정한다 — 목업 높이와 배지 top 이 전부 그
+  폭에서 나온 절대값이라, 좁은 창의 잘림을 회귀로 보고하면 안 된다.
+- fixture 의 `<head>` 는 커밋하지 않는다. `scaffold.py` 로 `template.html` 에서 매번
+  가져오고 슬라이드 조각(`tests/fixtures/layout/baseline-slides.html`)만 커밋한다 —
+  그래야 템플릿이 바뀔 때 fixture 가 따라온다.
+- CI 는 `.github/workflows/layout.yml` 의 **별도 job** 이다. stdlib 전용인 `test.yml` 에
+  브라우저를 끌어들이지 않는다. 그 job 은 Chrome 이 없으면 `google-chrome --version`
+  단계에서 실패한다 — 테스트가 조용히 skip 되어 초록으로 통과하는 것을 막는다.
 
 ### 내보내기 (PDF · PPTX)
 

--- a/skills/mobile-web-planner/SKILL.md
+++ b/skills/mobile-web-planner/SKILL.md
@@ -64,11 +64,18 @@ description: 사용자가 모바일 웹/앱의 기획서 / 화면설계서 / 스
 
 8. 위반이 있으면 산출물을 수정하고 검증을 다시 실행한다. 위반이 0건이 될
    때까지 반복한다.
-9. 브라우저 또는 HTML 렌더링 도구를 사용할 수 있으면 **`<스킬경로>/resources/badge-audit.js`
+9. Chrome 을 쓸 수 있으면 레이아웃 회귀도 함께 확인한다 — 정적 검사는 마크업만
+   보므로 슬라이드 밖으로 넘친 내용, 설명 패널 잘림은 렌더해야 보인다.
+
+   ```sh
+   python3 <스킬경로>/scripts/check_layout_runtime.py <생성한 HTML 경로>
+   ```
+
+10. 브라우저 또는 HTML 렌더링 도구를 사용할 수 있으면 **`<스킬경로>/resources/badge-audit.js`
    를 실행해 배지 정렬을 실측한다**(아래 "배지 좌표는 실측한다"). 반환값을 JSON 으로
    저장해 `<스킬경로>/scripts/apply_badge_audit.py` 로 인라인 top 을 일괄 반영한다 — 손 환산 금지.
    그다음 각 슬라이드의 잘림, 겹침과 가독성을 확인하고 발견한 문제를 수정한 뒤 다시 검증한다.
-10. 구조 검증을 통과한 두 파일의 경로와 결과에 영향을 준 주요 가정을 전달한다.
+11. 구조 검증을 통과한 두 파일의 경로와 결과에 영향을 준 주요 가정을 전달한다.
 
 기존 Storyboard 수정 요청에서는 기존 화면 ID를 가능한 한 유지한다. 삭제된
 ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여한다. 변경 범위
@@ -109,6 +116,10 @@ ID를 새 화면에 재사용하지 않고, 추가 화면에는 새 ID를 부여
 엉뚱한 요소를 가리킨 사례가 있다.
 
 - 정적 검사(`check_badge_alignment.py`)로 잡히는 것은 **겹침과 순서 역전**까지다.
+- 두 실측 도구는 보는 것이 다르다. `badge-audit.js` 는 배지가 **무엇을 가리키는가**(의미),
+  `check_layout_runtime.py` 는 레이아웃이 **깨졌는가**(구조 — 슬라이드 overflow, 배지가
+  자기 컨테이너 밖으로 이탈, 배지 겹침, 설명 패널 잘림)를 본다. 후자는 설계 기준 폭
+  (1400px)으로 고정해 렌더하므로 창 폭 때문에 생긴 잘림을 회귀로 보고하지 않는다.
 - 브라우저를 쓸 수 있으면 `<스킬경로>/resources/badge-audit.js` 를 실행한다. 반환값의
   `misaligned` 가 비어 있어야 한다. 어긋난 배지는 반환값을 JSON 으로 저장해
   **`<스킬경로>/scripts/apply_badge_audit.py <산출물.html> <audit.json>`** 으로 일괄 반영한다 —
@@ -502,7 +513,8 @@ Version: {{VERSION}}
 `<스킬경로>/scripts/validate_storyboard.py`의 종료 코드가 0이 아닌 산출물은 완료로 간주하지
 않는다. Business Rules 문서의 위반도 같은 종료 코드에 합산된다. `check_badge_overflow.py`
 와 `check_badge_alignment.py` 도 같은 기준이다. 세 검증을 통과하기 전에는 최종
-산출물로 전달하지 않는다.
+산출물로 전달하지 않는다. Chrome 이 있으면 `check_layout_runtime.py` 도 exit 0 이어야
+한다 — 없으면 그 사실을 결과에 적는다.
 
 ## PDF · PPTX 내보내기
 

--- a/skills/mobile-web-planner/resources/layout-probe.js
+++ b/skills/mobile-web-planner/resources/layout-probe.js
@@ -1,0 +1,85 @@
+/*
+ * layout-probe.js — 렌더된 화면설계서의 geometry 를 그대로 뽑아 온다.
+ *
+ * badge-audit.js 가 "배지가 무엇을 가리키는가"(의미)를 재는 반면, 이쪽은
+ * "레이아웃이 깨졌는가"(구조)만 잰다 — 슬라이드 overflow, 배지 이탈, 배지
+ * 겹침, 설명 패널 잘림·겹침. 템플릿 CSS 변경의 회귀를 잡는 것이 목적이라
+ * 판정 자체는 하지 않고 **원시 좌표만** 돌려준다. 임계값 판정은
+ * scripts/check_layout_runtime.py 가 한다 — 그래야 브라우저 없이도 판정
+ * 로직을 단위 테스트할 수 있고, 임계값이 파이썬 한 곳에만 존재한다.
+ *
+ * 사용법: check_layout_runtime.py 가 산출물에 주입해 실행한다. 수동으로는
+ * 브라우저 콘솔에 그대로 붙여 넣어도 같은 JSON 을 얻는다.
+ */
+(() => {
+  const R = (n) => Math.round(n * 10) / 10;
+  const box = (el) => {
+    const r = el.getBoundingClientRect();
+    return { top: R(r.top), left: R(r.left), right: R(r.right), bottom: R(r.bottom) };
+  };
+  // 배지의 좌표 원점이 되는 컨테이너들. mock-body 밖(헤더·푸터·필 탭)에 놓인
+  // 배지는 원점이 달라 서로 비교하면 안 된다 — 컨테이너 단위로 묶는다.
+  const HOSTS = ".mock-body, .mock-header, .mock-footer, .mock-footer-pill";
+
+  const slides = [...document.querySelectorAll(".ppt-slide")].map((slide, index) => {
+    const no = (slide.querySelector(".ppt-top-no")?.textContent || "").trim();
+
+    const containers = [...slide.querySelectorAll(HOSTS)].map((host) => ({
+      kind: host.className.split(/\s+/).find((c) => c.startsWith("mock-")) || "unknown",
+      rect: box(host),
+      // 스크롤 컨테이너(mock-body)는 잘려 보이는 부분이 실제 가시 영역이다.
+      clipped: host.scrollHeight > host.clientHeight + 1,
+      badges: [...host.querySelectorAll(":scope > .pointer-badge")].map((b) => ({
+        label: b.textContent.trim(),
+        ...box(b),
+      })),
+    })).filter((c) => c.badges.length);
+
+    const panels = [...slide.querySelectorAll(".ppt-desc-body")].map((panel) => ({
+      clientH: panel.clientHeight,
+      scrollH: panel.scrollHeight,
+    }));
+
+    const items = [...slide.querySelectorAll(".desc-list > li")].map((li) => ({
+      label: (li.querySelector(".desc-num")?.textContent || "").trim(),
+      ...box(li),
+    }));
+
+    // scrollWidth/Height 는 정수로 반올림된다. 슬라이드 높이가 787.5px 처럼
+    // 소수라 그 값만 보면 회귀가 없어도 ±3px 이 흔들린다. 실제로 잘리는지는
+    // 자손 rect 가 슬라이드 rect 를 넘는지로 잰다.
+    const sr = slide.getBoundingClientRect();
+    let overRight = 0;
+    let overBottom = 0;
+    slide.querySelectorAll("*").forEach((el) => {
+      const r = el.getBoundingClientRect();
+      if (!r.width && !r.height) return;
+      overRight = Math.max(overRight, r.right - sr.right);
+      overBottom = Math.max(overBottom, r.bottom - sr.bottom);
+    });
+
+    return {
+      index,
+      no,
+      mermaid: slide.querySelectorAll(".mermaid").length,
+      slide: {
+        w: R(sr.width),
+        h: R(sr.height),
+        overRight: R(overRight),
+        overBottom: R(overBottom),
+      },
+      containers,
+      panels,
+      items,
+    };
+  });
+
+  return {
+    viewport: { w: window.innerWidth, h: window.innerHeight },
+    mermaid: {
+      total: document.querySelectorAll(".mermaid").length,
+      rendered: [...document.querySelectorAll(".mermaid")].filter((m) => m.querySelector("svg")).length,
+    },
+    slides,
+  };
+})();

--- a/skills/mobile-web-planner/resources/template.html
+++ b/skills/mobile-web-planner/resources/template.html
@@ -448,7 +448,9 @@ body {
    렌더되지 않는다. 배지가 있는 헤더에만 mock-body 와 같은 gutter 를
    부여해 배지가 제목 첫 글자를 가리지 않게 한다. */
 .mock-header:has(.pointer-badge) { padding-left: 28px; }
+.mock-footer:has(.pointer-badge) { padding-left: 28px; }
 .ppt-wireframe:has(.mock ~ .mock) .mock-header:has(.pointer-badge) { padding-left: 34px; }
+.ppt-wireframe:has(.mock ~ .mock) .mock-footer:has(.pointer-badge) { padding-left: 34px; }
 /* padding-left 28px 는 pointer-badge 전용 gutter 다.
    배지를 left:-12px 로 프레임 밖에 두면 mock-body(overflow-y:auto 이므로
    overflow-x 도 auto 로 계산된다) 와 mock-screen(overflow:hidden) 이
@@ -461,6 +463,9 @@ body {
    슬라이드의 28px gutter 는 그대로다(이슈 #6 무회귀). */
 .ppt-wireframe:has(.mock ~ .mock) .mock-body { padding-left: 34px; }
 .mock-footer {
+  /* mock-header 와 같은 이유로 좌표 원점이다 (이슈 #71·#137) — 여기 없으면
+     푸터 안의 pointer-badge 가 .mock 기준으로 떠서 화면 최상단에 찍힌다. */
+  position: relative;
   border-top: 1px solid #e2e8f0;
   display: flex;
   justify-content: space-around;

--- a/skills/mobile-web-planner/scripts/check_layout_runtime.py
+++ b/skills/mobile-web-planner/scripts/check_layout_runtime.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""렌더된 산출물의 레이아웃 회귀를 Chrome headless 로 잡는다 (이슈 #137).
+
+정적 검사기(validate_storyboard·check_badge_overflow·check_badge_alignment)는
+마크업의 인라인 좌표만 본다. 템플릿 CSS 가 바뀌어 목업 높이·gutter·설명 패널
+밀도가 달라지면 마크업은 그대로인데 결과만 깨지고, 그건 렌더해야 보인다.
+
+전체 픽셀 비교는 브라우저·폰트 버전이 바뀔 때마다 false positive 를 내므로
+1차 계약은 **구조·좌표**다. 여기서 판정하는 것은 넷뿐이다.
+
+    slide-overflow   슬라이드가 자기 16:9 박스를 넘겼다 (내용이 잘린다)
+    badge-outside    배지가 자기 좌표 원점 컨테이너 밖으로 나갔다
+    badge-overlap    같은 컨테이너의 배지 둘이 겹쳤다 (번호를 못 읽는다)
+    desc-clipped     설명 패널 내용이 패널 높이를 넘겼다 (인쇄 시 잘린다)
+    desc-overlap     설명 항목끼리 겹쳤다
+
+좌표 수집은 resources/layout-probe.js 가 하고 **임계값 판정은 이 파일이
+한다** — 브라우저 없이도 판정 로직을 단위 테스트할 수 있게 하기 위해서다
+(tests/test_layout_runtime.py).
+
+기본은 오프라인 렌더다. 외부 폰트(@import)와 mermaid CDN 스크립트를 임시
+사본에서 떼고 그린다 — CI 러너의 네트워크 상태가 판정을 흔들면 회귀 검사가
+아니라 점집이 된다. mermaid 를 못 그리는 슬라이드는 slide-overflow 판정에서
+제외하고 그 사실을 보고한다. 실제 mermaid 높이까지 보려면 --online 을 쓴다.
+원본 파일은 절대 수정하지 않는다.
+
+사용법:
+    python3 scripts/check_layout_runtime.py <산출물.html> [...]
+        [--chrome <경로>] [--online] [--json <저장경로>]
+
+종료 코드: 위반 없으면 0, 있으면 1, 인자·Chrome 문제면 2.
+"""
+import argparse
+import html as _html
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_deck import (  # noqa: E402  Chrome 탐색·대기시간은 내보내기와 같은 계약을 쓴다
+    DESIGN_W,
+    RENDER_WAIT_MS,
+    WINDOW_H,
+    find_chrome,
+)
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+PROBE = SKILL_ROOT / "resources" / "layout-probe.js"
+
+#: 서브픽셀 반올림과 border 1px 은 회귀가 아니다. 이보다 큰 이탈만 본다.
+OVERFLOW_TOL = 2.0
+BADGE_TOL = 1.0
+#: 배지끼리 이만큼 이하로 겹치는 것은 그림자 여백 수준이라 읽기에 지장이 없다.
+OVERLAP_TOL = 1.0
+
+
+#: 설계 기준 폭으로 고정하는 CSS. 목업 높이(694px)와 배지 인라인 top 은 전부
+#: DESIGN_W=1400 에서 나온 절대값이라, 브라우저 창 폭에 따라 슬라이드가
+#: 좁아지면 목업이 슬라이드를 넘긴다 — 그건 회귀가 아니라 창이 좁은 것이다.
+#: PDF·PPTX 내보내기가 쓰는 것과 같은 기하로 맞춰 그 구분을 없앤다.
+DESIGN_CSS = ("body{margin:0 !important;padding:0 !important;background:#fff !important;}"
+              ".docwrap{max-width:none !important;gap:0 !important;}")
+
+
+def strip_network(html):
+    """외부 요청을 유발하는 태그를 떼어 낸 사본 문자열을 만든다."""
+    html = re.sub(r'<script\b[^>]*\bsrc="https?://[^"]*"[^>]*>\s*</script>', "", html)
+    html = re.sub(r'@import\s+url\([^)]*\);?', "", html)
+    # mermaid 블록은 스크립트가 없으면 원문 텍스트로 흘러 슬라이드를 넘긴다.
+    # 숨겨서 판정 대상에서 빼되, 슬라이드에 mermaid 가 있었다는 사실은
+    # probe 가 세어 보고한다.
+    return html.replace("</style>", ".mermaid{display:none !important;}</style>", 1)
+
+
+def measure(chrome, path, offline=True):
+    """Chrome 으로 한 번 렌더해 probe 의 JSON 을 받아 온다."""
+    snippet = PROBE.read_text(encoding="utf-8").strip().rstrip(";")
+    inject = ('<script>window.addEventListener("load",()=>{setTimeout(()=>{'
+              f"const r={snippet};"
+              'const p=document.createElement("pre");p.id="__layout__";'
+              'p.textContent=JSON.stringify(r);document.body.appendChild(p);'
+              '},1200)});</script>')
+    source = Path(path).read_text(encoding="utf-8")
+    if offline:
+        source = strip_network(source)
+    source = source.replace("</style>", DESIGN_CSS + "</style>", 1)
+    if "</body>" not in source:
+        sys.exit(f"오류: </body> 가 없는 문서다 — {path}")
+    source = source.replace("</body>", inject + "</body>", 1)
+
+    with tempfile.TemporaryDirectory() as work:
+        page = Path(work) / "probe.html"
+        page.write_text(source, encoding="utf-8")
+        result = subprocess.run(
+            [chrome, "--headless", "--disable-gpu", "--hide-scrollbars",
+             "--no-sandbox",
+             f"--virtual-time-budget={RENDER_WAIT_MS}",
+             f"--window-size={DESIGN_W},{WINDOW_H}",
+             "--dump-dom", f"file://{page.resolve()}"],
+            capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"오류: Chrome 실행 실패 (exit {result.returncode})\n{result.stderr[-600:]}")
+    found = re.search(r'<pre id="__layout__">(.*?)</pre>', result.stdout, re.DOTALL)
+    if not found:
+        sys.exit("오류: probe 결과를 받지 못했다 — 문서가 렌더되지 않았을 수 있다")
+    return json.loads(_html.unescape(found.group(1)))
+
+
+def _overlap(a, b):
+    """두 사각형이 겹치는 폭·높이 중 작은 쪽. 안 겹치면 0 이하."""
+    return min(
+        min(a["right"], b["right"]) - max(a["left"], b["left"]),
+        min(a["bottom"], b["bottom"]) - max(a["top"], b["top"]),
+    )
+
+
+def judge(report, offline=True):
+    """probe 측정값을 위반 목록으로 바꾼다. 브라우저 없이 테스트되는 지점."""
+    violations = []
+
+    def add(slide, kind, detail):
+        violations.append({"slide": slide.get("no") or f"#{slide['index'] + 1}",
+                           "kind": kind, "detail": detail})
+
+    for slide in report.get("slides", []):
+        geo = slide["slide"]
+        skip_overflow = offline and slide.get("mermaid")
+        if not skip_overflow:
+            over_w = geo["overRight"]
+            over_h = geo["overBottom"]
+            if over_w > OVERFLOW_TOL or over_h > OVERFLOW_TOL:
+                add(slide, "slide-overflow",
+                    f"내용이 슬라이드 밖으로 {max(over_w, over_h):.0f}px 넘쳤다 "
+                    f"(가로 {over_w:.0f}px · 세로 {over_h:.0f}px)")
+
+        for container in slide.get("containers", []):
+            rect = container["rect"]
+            for badge in container["badges"]:
+                out = max(rect["top"] - badge["top"], rect["left"] - badge["left"],
+                          badge["right"] - rect["right"], badge["bottom"] - rect["bottom"])
+                if out > BADGE_TOL:
+                    add(slide, "badge-outside",
+                        f"배지 {badge['label']} 가 {container['kind']} 밖으로 "
+                        f"{out:.0f}px 나갔다")
+            badges = container["badges"]
+            for i, first in enumerate(badges):
+                for second in badges[i + 1:]:
+                    if _overlap(first, second) > OVERLAP_TOL:
+                        add(slide, "badge-overlap",
+                            f"배지 {first['label']} 와 {second['label']} 가 "
+                            f"{container['kind']} 안에서 겹쳤다")
+
+        for panel in slide.get("panels", []):
+            clipped = panel["scrollH"] - panel["clientH"]
+            if clipped > OVERFLOW_TOL:
+                add(slide, "desc-clipped",
+                    f"설명 패널 내용이 {clipped:.0f}px 잘렸다 "
+                    f"(항목을 줄이거나 밀도 규칙을 확인)")
+
+        items = slide.get("items", [])
+        for i, first in enumerate(items):
+            for second in items[i + 1:]:
+                if _overlap(first, second) > OVERLAP_TOL:
+                    add(slide, "desc-overlap",
+                        f"설명 항목 {first['label']} 와 {second['label']} 가 겹쳤다")
+
+    return violations
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Chrome headless 로 산출물 레이아웃 회귀를 검사한다")
+    parser.add_argument("paths", nargs="+", help="검사할 산출물 HTML")
+    parser.add_argument("--chrome", help="Chrome 실행 파일 경로")
+    parser.add_argument("--online", action="store_true",
+                        help="외부 폰트·mermaid CDN 을 그대로 두고 렌더한다")
+    parser.add_argument("--json", help="측정 원본을 저장할 경로")
+    args = parser.parse_args(argv)
+
+    chrome = find_chrome(args.chrome)
+    offline = not args.online
+    total = 0
+    dumps = {}
+    for path in args.paths:
+        if not Path(path).is_file():
+            print(f"오류: 파일이 없다 — {path}", file=sys.stderr)
+            return 2
+        report = measure(chrome, path, offline=offline)
+        dumps[path] = report
+        violations = judge(report, offline=offline)
+        total += len(violations)
+        print(f"===== {path} =====")
+        skipped = [s["no"] or f"#{s['index'] + 1}"
+                   for s in report["slides"] if offline and s.get("mermaid")]
+        if skipped:
+            print(f"  - mermaid 슬라이드는 오프라인 렌더라 overflow 판정 제외: "
+                  f"{', '.join(skipped)}")
+        for item in violations:
+            print(f"  X {item['slide']} [{item['kind']}] {item['detail']}")
+        print(f"  => 레이아웃 위반 {len(violations)}건" if violations
+              else f"  => 레이아웃 위반 없음 (슬라이드 {len(report['slides'])}장)")
+    if args.json:
+        Path(args.json).write_text(json.dumps(dumps, ensure_ascii=False, indent=2),
+                                   encoding="utf-8")
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/mobile-web-planner/tests/fixtures/layout/baseline-slides.html
+++ b/skills/mobile-web-planner/tests/fixtures/layout/baseline-slides.html
@@ -1,0 +1,68 @@
+<!-- 레이아웃 회귀 검사용 기준 슬라이드 조각 (이슈 #137).
+
+     head 는 커밋하지 않는다 — scaffold.py 로 template.html 에서 매번 가져온다.
+     그래야 템플릿 CSS 가 바뀔 때 fixture 가 같이 따라오고, 회귀가 실제로
+     검사 대상이 된다. 여기에는 mermaid 와 외부 이미지가 없다 — 네트워크가
+     판정에 개입하지 않아야 한다. -->
+<div class="ppt-slide">
+
+  <div class="ppt-top-bar">
+    <div class="ppt-top-no">NO. 09.1</div>
+    <div class="ppt-top-title">Layout Baseline</div>
+    <div class="ppt-head-label">화면 Type</div>
+    <div class="ppt-head-value">MOBILE WEB</div>
+    <div class="ppt-head-label">요구사항 ID</div>
+    <div class="ppt-head-value">-</div>
+  </div>
+
+  <div class="ppt-meta-bar">
+    <div class="ppt-meta-label">화면 ID</div>
+    <div class="ppt-meta-id">FIX-LAYOUT-001</div>
+    <div class="ppt-meta-label">Location</div>
+    <div class="ppt-meta-value">기준</div>
+    <div class="ppt-meta-label" style="margin-left:auto;">작업자</div>
+    <div class="ppt-meta-value">UX 기획</div>
+  </div>
+
+  <div class="ppt-content">
+
+    <div class="ppt-wireframe">
+      <div class="mock">
+        <div class="mock-screen">
+          <div class="mock-status"></div>
+          <div class="mock-header"><span>기준 화면</span></div>
+          <div class="mock-body" style="position:relative; background:#f2f4f6; padding:16px 16px 16px 28px;">
+            <span class="pointer-badge" style="position:absolute; top:20px; left:2px; z-index:10;">1</span>
+            <div style="height:120px; background:#fff; border-radius:12px; border:1px solid #e5e8eb;"></div>
+            <span class="pointer-badge" style="position:absolute; top:170px; left:2px; z-index:10;">2</span>
+            <div style="margin-top:14px; height:180px; background:#fff; border-radius:12px; border:1px solid #e5e8eb;"></div>
+          </div>
+          <div class="mock-footer">
+            <span class="pointer-badge" style="position:absolute; top:9px; left:2px; z-index:10;">3</span>
+            <span style="font-size:11px; font-weight:700; color:#333;">홈</span>
+            <span style="font-size:11px; font-weight:700; color:#8b95a1;">검색</span>
+            <span style="font-size:11px; font-weight:700; color:#8b95a1;">마이</span>
+          </div>
+        </div>
+        <div class="mock-caption">기준 화면 (FIX-LAYOUT-001)</div>
+      </div>
+    </div>
+
+    <div class="ppt-desc-panel">
+      <div class="ppt-desc-header">Description (화면설명)</div>
+      <div class="ppt-desc-body">
+        <ul class="desc-list">
+          <li><span class="desc-num">1</span> <div><b>상단 카드</b><br>탭: 상세로 이동<br><code>Card</code></div></li>
+          <li><span class="desc-num">2</span> <div><b>본문 카드</b><br>스크롤: 목록 연속 노출<br><code>List</code></div></li>
+          <li><span class="desc-num">3</span> <div><b>하단 바</b><br>탭: 주요 액션 실행<br><code>Footer</code></div></li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="ppt-footer">
+    Layout Fixture | Ver.1.0.0
+  </div>
+
+</div>

--- a/skills/mobile-web-planner/tests/test_layout_runtime.py
+++ b/skills/mobile-web-planner/tests/test_layout_runtime.py
@@ -1,0 +1,201 @@
+"""check_layout_runtime.py 계약 테스트 (이슈 #137).
+
+두 층으로 나뉜다.
+
+1. 판정 로직 — probe 가 준 좌표를 위반으로 바꾸는 규칙. 브라우저 없이 항상
+   돈다. 임계값이 파이썬 한 곳에만 있기 때문에 가능하다.
+2. 실제 렌더 — Chrome 이 있을 때만 돈다. 템플릿에서 만든 기준 문서를 그려
+   위반 0건인지 본다. CI 에서는 별도 job(.github/workflows/layout.yml)이
+   Chrome 을 보장하고, 로컬 stdlib 테스트에서는 조용히 skip 된다.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = SKILL_ROOT / "scripts"
+FIXTURE = SKILL_ROOT / "tests" / "fixtures" / "layout" / "baseline-slides.html"
+PROBE = SKILL_ROOT / "resources" / "layout-probe.js"
+
+sys.path.insert(0, str(SCRIPTS))
+import check_layout_runtime as clr  # noqa: E402
+from export_deck import CHROME_CANDIDATES  # noqa: E402
+
+
+def rect(top, left, bottom, right):
+    return {"top": top, "left": left, "bottom": bottom, "right": right}
+
+
+def slide(**kw):
+    base = {
+        "index": 0,
+        "no": "NO. 09.1",
+        "mermaid": 0,
+        "slide": {"w": 1400, "h": 787.5, "overRight": 0, "overBottom": 0},
+        "containers": [],
+        "panels": [],
+        "items": [],
+    }
+    base.update(kw)
+    return base
+
+
+def kinds(report, offline=True):
+    return [v["kind"] for v in clr.judge(report, offline=offline)]
+
+
+class TestJudge(unittest.TestCase):
+    def test_clean_document_has_no_violation(self):
+        report = {"slides": [slide(
+            containers=[{"kind": "mock-body", "rect": rect(0, 0, 600, 320), "clipped": False,
+                         "badges": [{"label": "1", **rect(20, 2, 44, 26)},
+                                    {"label": "2", **rect(170, 2, 194, 26)}]}],
+            panels=[{"clientH": 500, "scrollH": 480}],
+            items=[{"label": "1", **rect(0, 0, 60, 400)},
+                   {"label": "2", **rect(76, 0, 130, 400)}],
+        )]}
+        self.assertEqual(clr.judge(report), [])
+
+    def test_slide_overflow_detected(self):
+        report = {"slides": [slide(
+            slide={"w": 1400, "h": 787.5, "overRight": 0, "overBottom": 40})]}
+        self.assertEqual(kinds(report), ["slide-overflow"])
+
+    def test_subpixel_overflow_is_not_a_regression(self):
+        report = {"slides": [slide(
+            slide={"w": 1400, "h": 787.5, "overRight": 1, "overBottom": 1})]}
+        self.assertEqual(kinds(report), [])
+
+    def test_badge_outside_its_container(self):
+        report = {"slides": [slide(containers=[
+            {"kind": "mock-body", "rect": rect(0, 0, 600, 320), "clipped": False,
+             "badges": [{"label": "9", **rect(590, 2, 614, 26)}]}])]}
+        self.assertEqual(kinds(report), ["badge-outside"])
+
+    def test_badges_overlapping_each_other(self):
+        report = {"slides": [slide(containers=[
+            {"kind": "mock-body", "rect": rect(0, 0, 600, 320), "clipped": False,
+             "badges": [{"label": "1", **rect(20, 2, 44, 26)},
+                        {"label": "2", **rect(30, 2, 54, 26)}]}])]}
+        self.assertEqual(kinds(report), ["badge-overlap"])
+
+    def test_badges_in_different_containers_are_not_compared(self):
+        """헤더와 본문은 좌표 원점이 달라 겹쳐 보여도 서로 다른 층이다."""
+        common = [{"label": "1", **rect(20, 2, 44, 26)}]
+        report = {"slides": [slide(containers=[
+            {"kind": "mock-header", "rect": rect(0, 0, 51, 320), "clipped": False,
+             "badges": common},
+            {"kind": "mock-body", "rect": rect(0, 0, 600, 320), "clipped": False,
+             "badges": [dict(common[0])]}])]}
+        self.assertEqual(kinds(report), [])
+
+    def test_desc_panel_clipped(self):
+        report = {"slides": [slide(panels=[{"clientH": 500, "scrollH": 640}])]}
+        self.assertEqual(kinds(report), ["desc-clipped"])
+
+    def test_desc_items_overlapping(self):
+        report = {"slides": [slide(items=[
+            {"label": "1", **rect(0, 0, 80, 400)},
+            {"label": "2", **rect(40, 0, 120, 400)}])]}
+        self.assertEqual(kinds(report), ["desc-overlap"])
+
+    def test_mermaid_slide_skips_overflow_only_offline(self):
+        report = {"slides": [slide(
+            mermaid=1,
+            slide={"w": 1400, "h": 787.5, "overRight": 0, "overBottom": 180})]}
+        self.assertEqual(kinds(report, offline=True), [])
+        self.assertEqual(kinds(report, offline=False), ["slide-overflow"])
+
+
+class TestNetworkStripping(unittest.TestCase):
+    def test_external_script_and_font_import_removed(self):
+        html = ('<html><head><style>@import url("https://fonts.example/x.css");'
+                'body{color:red}</style>'
+                '<script src="https://cdn.example/mermaid.min.js"></script></head>'
+                '<body><div class="mermaid">graph TD;</div></body></html>')
+        out = clr.strip_network(html)
+        self.assertNotIn("https://", out)
+        self.assertIn(".mermaid{display:none !important;}", out)
+        self.assertIn("body{color:red}", out, "본문 CSS 까지 지우면 안 된다")
+
+
+def build_fixture(target_dir):
+    """template.html 의 head 로 기준 문서를 조립한다. head 는 커밋하지 않는다."""
+    out = Path(target_dir) / "layout-baseline.html"
+    subprocess.run(
+        [sys.executable, str(SCRIPTS / "scaffold.py"), str(out),
+         "--project", "Layout Fixture", "--version", "1.0.0"],
+        check=True, capture_output=True, text=True)
+    from scaffold import INSERT_MARKER  # noqa: E402  scaffold 와 삽입 규약을 공유한다
+    html = out.read_text(encoding="utf-8")
+    if INSERT_MARKER not in html:
+        raise AssertionError("scaffold 산출물에 삽입 마커가 없다")
+    out.write_text(
+        html.replace(INSERT_MARKER,
+                     FIXTURE.read_text(encoding="utf-8") + "\n" + INSERT_MARKER, 1),
+        encoding="utf-8")
+    return out
+
+
+def chrome_available():
+    for cand in (os.environ.get("CHROME"), *CHROME_CANDIDATES):
+        if cand and (Path(cand).is_file() or shutil.which(cand)):
+            return True
+    return False
+
+
+@unittest.skipUnless(chrome_available(), "Chrome 이 없어 렌더 검사를 건너뛴다")
+class TestRenderedBaseline(unittest.TestCase):
+    def test_baseline_document_has_no_layout_violation(self):
+        with tempfile.TemporaryDirectory() as work:
+            doc = build_fixture(work)
+            dump = Path(work) / "measured.json"
+            code = clr.main([str(doc), "--json", str(dump)])
+            measured = json.loads(dump.read_text(encoding="utf-8"))[str(doc)]
+            self.assertTrue(measured["slides"], "슬라이드를 하나도 못 읽었다")
+            self.assertEqual(code, 0, "기준 문서에서 레이아웃 위반이 나왔다")
+
+    def test_broken_css_is_caught(self):
+        """검사기가 실제로 회귀를 잡는지 본다 — 통과만 확인하면 무의미하다.
+
+        목업을 200px 키우면 슬라이드를 넘고, 배지 gutter 를 없애면 배지가
+        본문 텍스트 위로 올라온다. 전자는 slide-overflow 로 잡혀야 한다.
+        """
+        with tempfile.TemporaryDirectory() as work:
+            doc = build_fixture(work)
+            broken = Path(work) / "broken.html"
+            broken.write_text(
+                doc.read_text(encoding="utf-8").replace(
+                    "</style>", ".mock{height:894px !important;}</style>", 1),
+                encoding="utf-8")
+            self.assertEqual(clr.main([str(broken)]), 1,
+                             "깨진 레이아웃을 통과시켰다")
+            report = clr.measure(clr.find_chrome(), broken)
+            self.assertIn("slide-overflow",
+                          [v["kind"] for v in clr.judge(report)])
+
+    def test_probe_reports_badges_and_items(self):
+        with tempfile.TemporaryDirectory() as work:
+            doc = build_fixture(work)
+            report = clr.measure(clr.find_chrome(), doc)
+            first = report["slides"][0]
+            badges = [b["label"] for c in first["containers"] for b in c["badges"]]
+            self.assertEqual(sorted(badges), ["1", "2", "3"])
+            self.assertEqual([i["label"] for i in first["items"]], ["1", "2", "3"])
+
+
+class TestProbeShape(unittest.TestCase):
+    def test_probe_is_a_single_expression_snippet(self):
+        """주입은 `const r=<snippet>` 형태다 — 세미콜론으로 끝나면 문법이 깨진다."""
+        text = PROBE.read_text(encoding="utf-8").strip()
+        self.assertTrue(text.endswith("})();"), "IIFE 로 끝나야 한다")
+        self.assertIn("return {", text, "측정값을 반환하지 않는다")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/mobile-web-planner/tests/test_template.py
+++ b/skills/mobile-web-planner/tests/test_template.py
@@ -33,6 +33,22 @@ class TestHeaderBadgeContract(unittest.TestCase):
         self.assertIn("position: relative", body,
                       "mock-header 가 배지의 좌표 원점(position:relative)이 아니다")
 
+    def test_mock_footer_is_positioning_origin(self):
+        """푸터도 배지의 좌표 원점이다 (이슈 #137).
+
+        없으면 푸터 안의 pointer-badge 가 .mock 기준으로 떠서 화면 최상단에
+        찍힌다 — 마크업은 멀쩡해 정적 검사로는 안 잡히고 렌더해야 보인다.
+        """
+        body = rule_body(css(), ".mock-footer")
+        self.assertIsNotNone(body, ".mock-footer 규칙이 없다")
+        self.assertIn("position: relative", body,
+                      "mock-footer 가 배지의 좌표 원점(position:relative)이 아니다")
+
+    def test_footer_gutter_for_badges(self):
+        body = rule_body(css(), ".mock-footer:has(.pointer-badge)")
+        self.assertIsNotNone(body, "배지 있는 푸터의 gutter 규칙이 없다")
+        self.assertIn("padding-left: 28px", body)
+
     def test_header_gutter_single_mock(self):
         body = rule_body(css(), ".mock-header:has(.pointer-badge)")
         self.assertIsNotNone(body, "배지 있는 헤더의 gutter 규칙이 없다")


### PR DESCRIPTION
이슈 #137 의 3번 항목(브라우저 기반 레이아웃 회귀 테스트)을 구현한다. 1·2번은 이미 main 에 들어와 있고, 4번은 RFC 결정이 선행이라 이 PR 범위 밖이다.

## 왜

정적 검사기 세 개는 마크업의 인라인 좌표만 본다. 템플릿 CSS 가 바뀌어 목업 높이·gutter·설명 패널 밀도가 달라지면 **마크업은 그대로인데 결과만 깨진다** — 렌더해야 보인다.

실제로 이 검사기가 첫 회귀를 잡았다: `.mock-footer` 에 `position: relative` 가 없어 푸터의 `pointer-badge` 가 `.mock` 기준으로 떠 화면 최상단에 찍히고 있었다(이슈 #71 은 `mock-header` 만 고쳤다). SKILL.md 는 푸터를 좌표 원점으로 전제하고 있었다. 좌표 원점과 배지 gutter 를 푸터에도 부여하고 정적 계약 테스트로 고정했다.

## 설계 결정

| 결정 | 이유 |
|---|---|
| 판정 대상은 구조·좌표 (픽셀 비교 없음) | 전체 픽셀 비교는 브라우저·폰트 버전이 바뀔 때마다 false positive 를 낸다. 이슈의 지침대로 구조·좌표를 1차 계약으로 둔다 |
| probe(JS)는 좌표만, 판정은 파이썬 | 임계값이 한 곳에만 있어야 하고, 브라우저 없이 판정 로직을 단위 테스트할 수 있다 |
| 기본 오프라인 렌더 | 외부 폰트 `@import` 와 mermaid CDN 제거. 러너 네트워크가 판정을 흔들면 회귀 검사가 아니다. mermaid 슬라이드는 overflow 판정에서 제외하고 그 사실을 출력에 찍는다 |
| 렌더 폭을 `DESIGN_W`(1400px)로 고정 | 목업 높이·배지 top 이 전부 그 폭에서 나온 절대값이다. 좁은 창의 잘림은 회귀가 아니다 |
| overflow 를 `scrollWidth/Height` 대신 자손 rect 로 측정 | 슬라이드 높이가 787.5px 라 정수 반올림만으로 ±3px 이 흔들린다 (실측) |
| fixture 의 head 는 커밋하지 않음 | `scaffold.py` 로 `template.html` 에서 매번 가져오고 슬라이드 조각만 커밋한다. 템플릿이 바뀌면 fixture 가 따라온다 |
| CI 는 별도 job | stdlib 전용 `test.yml` 에 브라우저를 끌어들이지 않는다. Chrome 이 없으면 `google-chrome --version` 단계에서 실패한다 — 테스트가 조용히 skip 되어 초록으로 통과하는 것을 막는다 |

## 판정 항목

- `slide-overflow` — 내용이 16:9 박스를 넘었다
- `badge-outside` — 배지가 자기 좌표 원점 컨테이너 밖으로 나갔다
- `badge-overlap` — 같은 컨테이너의 배지 둘이 겹쳤다
- `desc-clipped` — 설명 패널 내용이 패널 높이를 넘겨 인쇄 시 잘린다
- `desc-overlap` — 설명 항목끼리 겹쳤다

## 검증

```
./scripts/run_tests.sh          # 전부 통과 (mobile-web-planner 190건 포함)
```

렌더 테스트는 로컬 Chrome 으로 실측했다 — 기준 문서 위반 0건, 목업을 200px 키운 문서는 `slide-overflow` 로 잡힌다(통과만 확인하면 무의미하므로 검출 테스트를 함께 둔다). Chrome 이 없는 환경에서는 skip 되고, CI 의 layout job 이 그 경로를 보장한다.

Closes #137 의 3번 항목 (이슈는 Epic 이므로 닫지 않는다)
