### PR TITLE
feat(nextjs-implementer): Vite + React SPA 모드 라우트 대조와 버전 함정 (#139)

### DIFF
--- a/skills/nextjs-implementer/SKILL.md
+++ b/skills/nextjs-implementer/SKILL.md
@@ -151,10 +151,16 @@ description: mobile-web-planner의 Storyboard와 Business Rules를 동작하는 
 
 # 구현 규약 — Vite + React SPA 모드
 
-- 라우팅은 `react-router`의 프로젝트 설치 버전을 따른다. 새 프로젝트는
-  현재 안정 버전을 사용하되 v6/v7 API를 섞지 않는다.
+- 라우팅은 `react-router`의 프로젝트 설치 버전을 따른다. **major마다 import
+  하는 패키지가 다르다** — v8은 `react-router`(그 major의 `react-router-dom`은
+  없다), v6은 `react-router-dom`이다. 설치된 버전을 먼저 확인하고 major API를
+  섞지 않는다. 표는 references/implementation-modes.md 에 있다.
 - Screen List의 `화면`은 route object에, 팝업·바텀시트는 부모 route의 overlay
-  상태에 매핑한다. 새로고침과 직접 URL 진입도 테스트한다.
+  상태에 매핑한다. 새로고침과 직접 URL 진입도 테스트한다 — SPA fallback이
+  없으면 배포 환경에서만 404가 된다.
+- 라우트 등록 여부는 눈으로 확인하지 않는다. `validate_traceability.py` 에
+  `--routes <라우터 소스>` 를 주면 매핑표와 라우터를 양방향으로 대조한다.
+  등록되지 않은 화면은 빌드가 통과하고 그 URL 에서만 빈 화면이 된다.
 - 서버 상태는 API client 계층 뒤에 두고 로딩·오류·빈 상태를 route 단위로
   처리한다. `VITE_` 환경변수는 공개 값이므로 시크릿을 넣지 않는다.
 - mock 모드는 사용자가 프로토타입을 원하거나 API가 아직 없다고 명시한 경우만

--- a/skills/nextjs-implementer/references/implementation-modes.md
+++ b/skills/nextjs-implementer/references/implementation-modes.md
@@ -24,6 +24,68 @@ rewrite를 사용한다.
 새 프로젝트는 pnpm + Vite + React + TypeScript로 만들고 `react-router`를
 추가한다. 기존 프로젝트의 router major를 보존한다.
 
+### react-router 패키지 함정
+
+**어느 패키지에서 import 하는지가 major마다 다르다.** 2026-08-23 npm 레지스트리
+실측 기준이다.
+
+| major | 설치·import | 비고 |
+|---|---|---|
+| v8 (`react-router` 8.x) | `react-router` | `react-router-dom` 은 8.x가 없다. peer가 react·react-dom **>=19.2.7** 이라 React를 못 올리면 v8도 못 쓴다 |
+| v7 (`react-router` 7.x) | `react-router` (권장) 또는 `react-router-dom` 7.x | `react-router-dom` 7.x는 `react-router` 7.x를 그대로 재수출하는 얇은 래퍼다 |
+| v6 (`react-router-dom` 6.x) | `react-router-dom` | dist-tag `version-6` 로 유지된다 |
+
+기존 프로젝트는 설치된 버전을 먼저 확인하고 그 major의 표기를 따른다. **v6/v7
+API를 한 파일 안에서 섞지 않는다.** React 버전을 올리는 결정은 이 스킬이
+임의로 하지 않는다 — 필요하면 근거와 함께 사용자에게 묻는다.
+
+### 화면 ID → 라우트 매핑
+
+`화면`은 route object에, `팝업`·`바텀시트`는 부모 route의 오버레이 상태에
+매핑한다. 오버레이는 라우트를 갖지 않으므로 `traceability.json`에 `route`를
+쓰지 않고 부모 화면의 구현 파일을 가리킨다.
+
+```tsx
+// src/routes.tsx — 화면 ID를 주석이 아니라 매핑표(traceability.json)로 추적한다
+export const routes = [
+  { path: "/", element: <Home /> },              // DTC-MAIN-001
+  { path: "/board", element: <BoardList /> },    // DTC-BOARD-001
+  { path: "/board/:boardId", element: <BoardDetail /> }, // DTC-BOARD-002
+  { path: "*", element: <NotFound /> },
+];
+```
+
+라우터에 등록하지 않은 화면은 **빌드도 타입 검사도 통과한다** — 그 URL로
+들어갔을 때만 빈 화면이 된다. 그래서 기계로 대조한다.
+
+```sh
+python3 <스킬경로>/scripts/validate_traceability.py \
+  docs/traceability.json docs/<프로젝트>_business-rules.md --repo-root . \
+  --routes src/routes.tsx
+```
+
+문서에만 있는 라우트와 라우터에만 있는 라우트를 양방향으로 보고한다. `*`와
+index는 화면 ID를 갖지 않으므로 대조 대상이 아니다.
+
+### 직접 진입과 새로고침
+
+SPA는 서버가 모든 경로를 `index.html`로 돌려주지 않으면 **직접 URL 진입과
+새로고침이 404가 된다.** `vite dev`는 자동으로 처리하므로 개발 중에는 드러나지
+않는다 — 배포 환경(nginx `try_files`, 정적 호스팅의 SPA fallback 설정)에서
+반드시 확인한다. 확인하지 못했으면 그 사실을 잔여 위험으로 보고한다.
+
+### mock ↔ 실제 API 전환
+
+데이터 계층 인터페이스는 하나, 어댑터는 둘이다. 컴포넌트는 어느 쪽인지 모른다.
+
+- 전환은 **빌드 타임 플래그**(`import.meta.env.VITE_USE_MOCK` 등)로 하고,
+  컴포넌트 안에서 분기하지 않는다.
+- mock 어댑터는 동적 import로 분리해 프로덕션 번들에 들어가지 않게 한다.
+  들어갔는지는 `frontend-build/scripts/check_bundle.py <dist>`로 확인한다.
+- `VITE_` 로 시작하는 값은 전부 번들에 그대로 박히는 **공개 값**이다. API 키·
+  토큰을 넣지 않는다. 비밀이 필요하면 그 호출은 프론트가 할 일이 아니다.
+- mock으로 끝난 구현은 영속성·인증·권한을 검증했다고 보고하지 않는다.
+
 ```sh
 pnpm lint
 pnpm exec tsc --noEmit

--- a/skills/nextjs-implementer/scripts/validate_traceability.py
+++ b/skills/nextjs-implementer/scripts/validate_traceability.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Business Rules와 traceability.json의 화면·규칙·파일 연결을 검증한다."""
+"""Business Rules와 traceability.json의 화면·규칙·파일 연결을 검증한다.
+
+`--routes` 를 주면 라우터 소스와도 대조한다 (이슈 #139). SPA 모드에서 가장
+흔한 이탈이 "매핑표에는 있는데 라우터에 등록되지 않은 화면" 이다 — 빌드도
+타입 검사도 통과하고, 그 URL 로 들어갔을 때만 빈 화면이 된다. 반대 방향(라우터에는
+있는데 문서에 없는 라우트)도 같이 본다.
+"""
 
 import argparse
 import json
@@ -10,6 +16,13 @@ from pathlib import Path
 
 
 SCREEN_RE = re.compile(r"(?m)^##\s+([A-Z]{2,6}-[A-Z]{2,12}-\d{3})\b")
+#: 라우터 소스에서 경로 리터럴을 뽑는다. route object(`path: "/x"`)와 JSX
+#: (`<Route path="/x">`) 두 표기를 모두 쓴다 — 프로젝트마다 다르고, 하나만
+#: 지원하면 검사가 조용히 0건이 된다.
+ROUTE_OBJ_RE = re.compile(r"""\bpath\s*:\s*['"`]([^'"`]*)['"`]""")
+ROUTE_JSX_RE = re.compile(r"""<Route\b[^>]*\bpath\s*=\s*['"{`]+([^'"`}]*)['"`}]+""")
+#: 문서와 대조할 대상이 아닌 라우트. 404 와 index 는 화면 ID 를 갖지 않는다.
+ROUTE_IGNORED = {"*", "", "/*"}
 RULE_RE = re.compile(
     r"\b([A-Z]{2,6}-[A-Z]{2,12}-\d{3}\.(?:IN|OUT|INT|EDGE)-\d{2})\b")
 
@@ -18,7 +31,26 @@ def duplicates(values):
     return sorted(value for value, count in Counter(values).items() if count > 1)
 
 
-def validate(manifest, rules_md, repo_root):
+def collect_routes(sources):
+    """라우터 소스에서 선언된 경로 집합을 뽑는다."""
+    found = set()
+    for text in sources:
+        found.update(ROUTE_OBJ_RE.findall(text))
+        found.update(ROUTE_JSX_RE.findall(text))
+    return {route for route in found if route not in ROUTE_IGNORED}
+
+
+def normalize_route(route):
+    """비교용 정규화. 끝 슬래시와 파라미터 이름 차이는 같은 라우트로 본다."""
+    route = route.strip()
+    if len(route) > 1:
+        route = route.rstrip("/")
+    if not route.startswith("/"):
+        route = "/" + route
+    return re.sub(r":[A-Za-z_][A-Za-z0-9_]*", ":param", route)
+
+
+def validate(manifest, rules_md, repo_root, router_sources=None):
     violations = []
     br_screens = SCREEN_RE.findall(rules_md)
     br_rules = RULE_RE.findall(rules_md)
@@ -67,6 +99,27 @@ def validate(manifest, rules_md, repo_root):
                     if not isinstance(path, str) or not (repo_root / path).is_file():
                         violations.append(f"{rule_id} 테스트 파일 없음: {path}")
 
+    routes = [(screen.get("screenId"), screen.get("route"))
+              for screen in screens
+              if isinstance(screen, dict) and screen.get("route")]
+    seen = {}
+    for screen_id, route in routes:
+        key = normalize_route(route)
+        if key in seen:
+            violations.append(
+                f"라우트 중복: {seen[key]} 와 {screen_id} 가 모두 {route} 다")
+        else:
+            seen[key] = screen_id
+
+    if router_sources is not None:
+        declared = {normalize_route(route) for route in collect_routes(router_sources)}
+        for screen_id, route in routes:
+            if normalize_route(route) not in declared:
+                violations.append(
+                    f"{screen_id}의 라우트가 라우터에 등록되지 않았다: {route}")
+        for orphan in sorted(declared - set(seen)):
+            violations.append(f"문서에 없는 라우트가 라우터에 있다: {orphan}")
+
     for label, values in (("화면", manifest_screens), ("규칙", manifest_rules)):
         dup = duplicates(values)
         if dup:
@@ -92,6 +145,8 @@ def main(argv=None):
     parser.add_argument("manifest", type=Path)
     parser.add_argument("business_rules", type=Path)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--routes", type=Path, nargs="*", default=None,
+                        help="라우터 소스 파일. 주면 라우트 등록 여부까지 대조한다")
     args = parser.parse_args(argv)
     try:
         manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
@@ -99,7 +154,14 @@ def main(argv=None):
     except (OSError, json.JSONDecodeError) as exc:
         print(f"오류: 입력을 읽을 수 없음: {exc}", file=sys.stderr)
         return 2
-    violations = validate(manifest, rules_md, args.repo_root)
+    sources = None
+    if args.routes is not None:
+        try:
+            sources = [path.read_text(encoding="utf-8") for path in args.routes]
+        except OSError as exc:
+            print(f"오류: 라우터 소스를 읽을 수 없음: {exc}", file=sys.stderr)
+            return 2
+    violations = validate(manifest, rules_md, args.repo_root, sources)
     for violation in violations:
         print(f"[위반] {violation}")
     if violations:

--- a/skills/nextjs-implementer/tests/test_traceability.py
+++ b/skills/nextjs-implementer/tests/test_traceability.py
@@ -65,5 +65,97 @@ class TestTraceability(unittest.TestCase):
         self.assertIn("중복 규칙 ID", joined)
 
 
+class TestRouteRegistration(unittest.TestCase):
+    """SPA 모드에서 매핑표와 라우터가 어긋나는 경우 (이슈 #139).
+
+    빌드도 타입 검사도 통과하고, 그 URL 로 들어갔을 때만 빈 화면이 된다 —
+    그래서 기계 대조가 필요하다.
+    """
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        (self.root / "src").mkdir()
+        for name in ("home.tsx", "home.test.tsx", "board.tsx", "board.test.tsx"):
+            (self.root / "src" / name).write_text("export {}", encoding="utf-8")
+
+    def manifest(self, *screens):
+        return {"screens": list(screens)}
+
+    def screen(self, screen_id, route, stem):
+        return {
+            "screenId": screen_id,
+            "route": route,
+            "implementation": [f"src/{stem}.tsx"],
+            "rules": [{"ruleId": f"{screen_id}.OUT-01",
+                       "tests": [f"src/{stem}.test.tsx"]}],
+        }
+
+    def rules_for(self, *screen_ids):
+        return "\n".join(
+            f"## {sid} 화면\n\n### 출력 규칙\n| {sid}.OUT-01 · 로딩 | 스켈레톤 |\n"
+            for sid in screen_ids)
+
+    def test_route_object_syntax_is_read(self):
+        router = 'createBrowserRouter([{ path: "/", element: <Home/> }])'
+        result = validator.validate(
+            self.manifest(self.screen("DTC-MAIN-001", "/", "home")),
+            self.rules_for("DTC-MAIN-001"), self.root, [router])
+        self.assertEqual(result, [])
+
+    def test_jsx_route_syntax_is_read(self):
+        router = '<Route path="/board" element={<Board/>} />'
+        result = validator.validate(
+            self.manifest(self.screen("DTC-BOARD-001", "/board", "board")),
+            self.rules_for("DTC-BOARD-001"), self.root, [router])
+        self.assertEqual(result, [])
+
+    def test_unregistered_route_is_reported(self):
+        router = 'createBrowserRouter([{ path: "/", element: <Home/> }])'
+        joined = "\n".join(validator.validate(
+            self.manifest(self.screen("DTC-BOARD-001", "/board", "board")),
+            self.rules_for("DTC-BOARD-001"), self.root, [router]))
+        self.assertIn("라우터에 등록되지 않았다", joined)
+
+    def test_orphan_route_in_router_is_reported(self):
+        router = ('createBrowserRouter([{ path: "/", element: <Home/> },'
+                  '{ path: "/secret", element: <Secret/> }])')
+        joined = "\n".join(validator.validate(
+            self.manifest(self.screen("DTC-MAIN-001", "/", "home")),
+            self.rules_for("DTC-MAIN-001"), self.root, [router]))
+        self.assertIn("문서에 없는 라우트", joined)
+
+    def test_catch_all_is_not_an_orphan(self):
+        router = ('createBrowserRouter([{ path: "/", element: <Home/> },'
+                  '{ path: "*", element: <NotFound/> }])')
+        self.assertEqual(validator.validate(
+            self.manifest(self.screen("DTC-MAIN-001", "/", "home")),
+            self.rules_for("DTC-MAIN-001"), self.root, [router]), [])
+
+    def test_param_names_and_trailing_slash_do_not_split_routes(self):
+        router = 'createBrowserRouter([{ path: "/board/:boardId" }])'
+        self.assertEqual(validator.validate(
+            self.manifest(self.screen("DTC-BOARD-001", "/board/:id/", "board")),
+            self.rules_for("DTC-BOARD-001"), self.root, [router]), [])
+
+    def test_duplicate_route_is_reported_without_router(self):
+        """라우터 소스를 안 줘도 두 화면이 같은 라우트인 것은 잡는다."""
+        joined = "\n".join(validator.validate(
+            self.manifest(self.screen("DTC-MAIN-001", "/", "home"),
+                          self.screen("DTC-BOARD-001", "/", "board")),
+            self.rules_for("DTC-MAIN-001", "DTC-BOARD-001"), self.root))
+        self.assertIn("라우트 중복", joined)
+
+    def test_overlay_screens_without_route_are_untouched(self):
+        """팝업·바텀시트는 라우트가 없다 — 없다고 위반이 되면 안 된다."""
+        overlay = self.screen("DTC-POPUP-001", None, "board")
+        overlay.pop("route")
+        self.assertEqual(validator.validate(
+            self.manifest(self.screen("DTC-MAIN-001", "/", "home"), overlay),
+            self.rules_for("DTC-MAIN-001", "DTC-POPUP-001"), self.root,
+            ['createBrowserRouter([{ path: "/" }])']), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
이슈 #139 의 남은 부분(Phase 2·3)을 구현한다. 어댑터 4종은 이미 Vite 모드를 설명하고 있어 손대지 않았고, **실제로 비어 있던 것은 라우팅 매핑의 기계 검증과 버전 함정**이었다.

## 1. 라우트 등록 대조 (`--routes`)

SPA 모드에서 가장 흔한 이탈은 "매핑표에는 있는데 라우터에 등록되지 않은 화면"이다. 이건 **빌드도 타입 검사도 통과하고, 그 URL 로 들어갔을 때만 빈 화면**이 된다 — 사람 눈으로는 안 잡힌다.

```sh
python3 scripts/validate_traceability.py docs/traceability.json docs/x_business-rules.md \
  --repo-root . --routes src/routes.tsx
```

- route object(`path: "/x"`)와 JSX(`<Route path="/x">`) 두 표기를 모두 읽는다. 하나만 지원하면 프로젝트에 따라 검사가 조용히 0건이 된다.
- 양방향으로 본다 — 문서에만 있는 라우트, 라우터에만 있는 라우트 둘 다 보고.
- 파라미터 이름(`:id` ↔ `:boardId`)과 끝 슬래시 차이는 같은 라우트로 정규화한다.
- `*`(404)는 화면 ID 가 없으므로 대조 대상이 아니고, **라우트 없는 오버레이(팝업·바텀시트)는 위반이 아니다.**
- 라우트 중복은 라우터 소스를 주지 않아도 잡는다.

`--routes` 는 옵션이라 Next.js 모드의 기존 동작에는 영향이 없다.

## 2. react-router 버전 함정 (npm 실측)

2026-08-23 npm 레지스트리 확인 결과를 표로 넣었다. 기억이 아니라 실측이다.

| major | import | 근거 |
|---|---|---|
| v8 (`react-router` **8.3.0**) | `react-router` | 그 major 의 `react-router-dom` 은 **없다** — 7.18.2 에서 멈춤 |
| v7 | `react-router` 권장 | `react-router-dom` 7.x 는 `react-router` 7.x 재수출 래퍼 |
| v6 | `react-router-dom` | dist-tag `version-6` = 6.30.6 |

v8 peer 는 react·react-dom **>=19.2.7** 이라 React 를 못 올리면 v8 도 못 쓴다. 이 사실이 없으면 에이전트가 v6 관례대로 `react-router-dom` 을 설치한다 — 저장소 유지 원칙("버전에 묶인 사실은 어느 버전부터인지 함께 적는다")에 맞춰 major 별로 적었다.

## 3. 그 밖의 SPA 계약

- **SPA fallback** — `vite dev` 는 자동 처리하므로 개발 중엔 안 드러나고 배포 환경에서만 404 가 된다. 확인 못 했으면 잔여 위험으로 보고.
- **mock ↔ 실 API 전환** — 인터페이스 하나 · 어댑터 둘, 전환은 빌드 타임 플래그, mock 어댑터는 동적 import 로 분리해 프로덕션 번들에서 배제(`check_bundle.py` 로 확인). `VITE_` 값은 전부 번들에 박히는 공개 값이라 키를 넣지 않는다.

## 검증

```
./scripts/run_tests.sh   # 전부 통과 (nextjs-implementer 32건)
```

라우트 대조는 8개 케이스로 고정했다 — 두 문법 인식, 미등록 검출, 고아 라우트 검출, `*` 예외, 파라미터/슬래시 정규화, 중복 검출, 오버레이 무해.

Closes #139
