### PR TITLE
chore: 생성 산출물·데모·툴체인 캐시를 무시하고 규칙을 테스트로 고정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,84 @@
-demo/
- demo1/
+# gitignore 는 줄 끝 주석을 지원하지 않는다 (# 은 줄 맨 앞에서만 주석).
+# 설명은 반드시 패턴 위에 별도 줄로 적는다.
+
+# --- 에이전트 하네스 스크래치 ---
+# 세션 작업공간 · worktree · 중간 리포트가 쌓이는 곳. 저장소의 산출물이 아니다.
+.superpowers/
+.gemini/
+
+# Agent Adapter 원본은 skills/<skill>/agents/ 가 소유하고, 아래 두 경로에는
+# 런타임이 탐색하는 이름의 심링크만 둔다. 그래서 스킬명을 하드코딩하지 않고
+# agents 디렉터리 전체를 추적하되 나머지 로컬 설정은 무시한다.
+.claude/*
+!.claude/agents/
+# 프로젝트 auto-memory SSOT — 팀 공유 지식이라 추적한다(개인 메모리는 user_*.md 만 제외).
+!.claude/memory/
+.claude/memory/user_*.md
+.codex/*
+!.codex/agents/
+
+# --- 실행 산출물 ---
+# tmp: 스크래치 HTML, 로컬 서버로 확인하는 임시 문서
+# output: 런타임별(Claude Code / Codex / Antigravity) 기획서 생성 결과 비교용
+# lastworks.resume: 세션 재개 포인터 (로컬 전용)
+tmp/
+output/
+lastworks.resume
+
+# --- Python ---
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# --- 비밀값 ---
+# 이 저장소는 현재 비밀값을 쓰지 않지만, 공개 저장소이므로 실수로 커밋되는
+# 경로를 미리 막는다.
+.env
+.env.*
+*.pem
+*.key
+
+# --- 에디터 · OS ---
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store
+Thumbs.db
+
+# --- 데모 · 실습 산출물 ---
+# 스킬을 시연하려고 저장소 안에서 한 번 돌려 보는 폴더. 그 안의 생성 HTML·
+# 스크립트는 저장소의 산출물이 아니다. demo1/ demos/ 같은 변형도 함께 막는다.
+demo*/
+
+# --- 생성 산출물 (mobile-web-planner) ---
+# 저장소는 기획 산출물을 커밋하지 않는다. 다만 tests/fixtures/ 아래의 픽스처는
+# 추적 대상이므로 루트에 떨어진 것만 막는다 — 앞의 `/` 가 그 앵커다.
+/*_storyboard.html
+/*_business-rules.md
+# export_deck.py 의 내보내기 결과. 추적되는 pdf·pptx 는 하나도 없다.
+*.pdf
+*.pptx
+
+# --- 코드 인덱스 ---
+# CodeGraph 가 만드는 로컬 인덱스(수 MB). 기계마다 다시 만들어지는 캐시다.
+.codegraph/
+
+# --- JS 툴체인 ---
+# 이 저장소 자체는 Node 를 쓰지 않지만, 스킬을 시연하거나 산출물을 확인하려고
+# 저장소 안에서 프로젝트를 돌리는 일이 실제로 생긴다.
+node_modules/
+dist/
+.next/
+*.log
+
+# --- Codex 프로젝트 스킬 경로 ---
+# 런타임이 탐색하는 자리. 설치기가 심링크를 만들면 여기 생긴다.
+.agents/
+
+# --- 로컬 스크래치 ---
+# 특정 산출물을 한 번 뽑아보려고 만드는 생성 스크립트와 작업 폴더.
+# 저장소는 생성 산출물(HTML)과 그 생성기를 커밋하지 않는다.
+scratch/
+generate_*.py

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,85 @@
+"""`.gitignore` 계약 테스트 (stdlib only).
+
+두 방향을 모두 본다.
+
+1. **추적 중인 파일이 무시되면 안 된다.** `*_business-rules.md` 처럼 산출물
+   이름을 그대로 쓰는 픽스처가 있어서, 무심코 전역 패턴을 넣으면 픽스처가
+   조용히 무시 대상이 된다. 이미 추적 중인 파일은 계속 추적되므로 그 순간에는
+   아무 일도 안 일어나고, **다음에 추가되는 픽스처만 사라진다.**
+2. **막기로 한 것은 실제로 막혀야 한다.** 규칙을 지우거나 파일을 통째로
+   갈아엎으면 여기서 잡힌다.
+
+판정은 문자열 매칭이 아니라 `git check-ignore` 다 — 패턴 문법(앵커 `/`,
+디렉터리 `/`, 순서)을 우리가 다시 구현하지 않는다.
+"""
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: 무시돼야 하는 경로. 왜 막는지는 .gitignore 의 주석에 있다.
+MUST_IGNORE = (
+    "demo/storyboard.html",
+    "demo1/generate.py",
+    "demos/out.html",
+    "some_storyboard.html",
+    "some_business-rules.md",
+    "deck.pdf",
+    "deck.pptx",
+    ".codegraph/index.db",
+    "node_modules/react/index.js",
+    "dist/assets/app.js",
+    ".next/trace",
+    "run.log",
+    "__pycache__/x.pyc",
+    "output/x.html",
+    "tmp/x.html",
+    ".env",
+)
+
+#: 무시되면 안 되는 경로. 산출물과 이름이 겹치는 픽스처들이다.
+MUST_TRACK = (
+    "skills/mobile-web-planner/tests/fixtures/runtime-parity/agy_business-rules.md",
+    "skills/mobile-web-planner/tests/fixtures/runtime-parity/agy.html",
+    "skills/mobile-web-planner/tests/fixtures/layout/baseline-slides.html",
+    "skills/mobile-web-planner/resources/template.html",
+    ".claude/agents/mobile-web-planner.md",
+)
+
+
+def check_ignore(paths):
+    """무시되는 경로만 돌려준다. git 이 판정 주체다."""
+    result = subprocess.run(
+        ["git", "check-ignore", "--stdin"], cwd=REPO,
+        input="\n".join(paths), capture_output=True, text=True)
+    if result.returncode not in (0, 1):  # 0=일부 매치, 1=매치 없음
+        raise AssertionError(f"git check-ignore 실패: {result.stderr.strip()}")
+    return set(result.stdout.split())
+
+
+class TestGitignore(unittest.TestCase):
+    def test_no_tracked_file_is_ignored(self):
+        tracked = subprocess.run(
+            ["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True
+        ).stdout.split()
+        self.assertTrue(tracked, "추적 파일 목록이 비었다 — git 저장소가 맞는지 확인")
+        ignored = check_ignore(tracked)
+        self.assertEqual(sorted(ignored), [],
+                         "추적 중인 파일이 .gitignore 에 걸린다")
+
+    def test_generated_artifacts_are_ignored(self):
+        ignored = check_ignore(MUST_IGNORE)
+        for path in MUST_IGNORE:
+            with self.subTest(path=path):
+                self.assertIn(path, ignored, f"{path} 가 무시되지 않는다")
+
+    def test_fixtures_are_not_ignored(self):
+        ignored = check_ignore(MUST_TRACK)
+        for path in MUST_TRACK:
+            with self.subTest(path=path):
+                self.assertNotIn(path, ignored, f"{path} 가 무시된다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
저장소 안에 실제로 굴러다니던 것들을 무시 대상에 넣고, 규칙 자체를 테스트로 고정한다.

## 무엇을 추가했나

| 패턴 | 실제로 있던 것 |
|---|---|
| `demo*/` | `demo/` 에 생성 storyboard·일회성 스크립트(`generate_full.py`, `insert_seq.py`, `screenshot5174.mjs` 등)가 들어 있다. `demo1/`·`demos/` 변형도 함께 막는다 |
| `/*_storyboard.html` · `/*_business-rules.md` | 기획 산출물. 저장소는 생성 산출물을 커밋하지 않는다 |
| `*.pdf` · `*.pptx` | `export_deck.py` 의 내보내기 결과. 추적되는 pdf·pptx 는 하나도 없다(확인함) |
| `.codegraph/` | CodeGraph 로컬 인덱스 4.8MB. 기계마다 다시 만들어지는 캐시 |
| `node_modules/` · `dist/` · `.next/` · `*.log` | 저장소 자체는 Node 를 쓰지 않지만, 스킬을 시연하거나 산출물을 확인하려고 저장소 안에서 프로젝트를 돌리는 일이 실제로 생긴다 |
| `.agents/` | Codex 가 탐색하는 프로젝트 스킬 경로 |

## 왜 루트 앵커인가

`*_business-rules.md` 를 전역으로 막으면 `tests/fixtures/runtime-parity/` 의 픽스처 3개(`agy_`·`claude_`·`codex_business-rules.md`)가 걸린다. **이미 추적 중인 파일은 계속 추적되므로 그 순간에는 아무 일도 일어나지 않고, 다음에 추가되는 픽스처만 조용히 사라진다** — 가장 늦게 발견되는 종류의 실수다. 그래서 루트에 떨어진 것만 막는 `/` 앵커를 쓴다.

## 테스트

`tests/test_gitignore.py` 가 양방향을 본다.

1. **추적 중인 파일이 하나도 무시되지 않는다** — 위의 픽스처 함정을 기계로 막는다.
2. **막기로 한 경로가 실제로 막힌다** — 규칙을 지우거나 파일을 통째로 갈아엎으면 여기서 실패한다.

판정 주체는 `git check-ignore` 다. 앵커·디렉터리 슬래시·순서 같은 패턴 문법을 우리가 다시 구현하면 그 구현이 또 틀린다.

```
./scripts/run_tests.sh   # 전부 통과
```

## PR #142 로 실제로 유실됐다 (복구 포함)

PR #142 가 머지되면서 이 파일이 **54줄에서 2줄로 교체됐다**(`.superpowers/`·`.claude/*`·`output/`·`__pycache__`·`.env` 등 기존 규칙 전부 삭제). 그 2줄 중 `' demo1/'` 은 앞에 공백이 있어 gitignore 문법상 이름이 ` demo1` 인 디렉터리를 가리킨다 — 의도한 대로 동작하지 않는다.

이 PR 은 새 main 위로 리베이스해 그 규칙을 복구하고, 위의 추가분을 얹는다. #142 가 의도한 데모 폴더 무시는 `demo*/` 로 이미 처리된다.