### PR TITLE
chore(sdlc-orchestrator): 파이프라인 게이트를 실제 자산과 맞추고 드리프트를 테스트로 막는다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,12 @@ doksam 프로젝트 UI 를 ui.doksam.com 표준에 맞추는 스킬입니다. **
 - 스킬은 SCA·동적 분석·모의해킹을 대체한다고 약속하지 않습니다.
 - AI-SDLC 단계 계약과 pre-commit 예시는 스킬 소유 reference에 둡니다.
 
+## 6.2 스킬별 작업 지침: sdlc-orchestrator
+
+`sdlc-orchestrator` 는 기획 → 구현 → 보안 → 로컬 기동을 순서대로 위임하는 메타 스킬입니다. **각 단계의 규칙을 복제하지 않고 게이트만 확인합니다** — 단계별 입출력과 중단 조건의 원본은 `skills/finguard/references/ai-sdlc.md` 입니다.
+
+문서가 가리키는 게이트가 실제로 존재해야 합니다. 경로가 틀리거나 단계를 "추가 예정" 으로 적어 두면 에이전트는 오류 없이 그 단계를 **조용히 건너뛰고 검증했다고 보고합니다** — 게이트가 있다고 믿는 상태가 없는 상태보다 나쁩니다. 실제로 이 스킬이 `finguard` 를 "추가 예정" 으로 적은 채 머지된 적이 있습니다. `tests/test_referenced_paths.py` 가 저장소의 모든 스킬 문서에 대해 두 가지를 강제합니다 — 문서가 가리키는 스크립트·reference 가 존재하는지, 이미 있는 스킬을 미구현으로 적지 않았는지.
+
 ## 7. 스킬별 작업 지침: 기술 스택 스킬 5종
 
 `frontend-build` · `react-expert` · `go-expert` · `sqlite-expert` · `db-expert` 는 하나의 묶음으로 관리합니다.

--- a/skills/sdlc-orchestrator/SKILL.md
+++ b/skills/sdlc-orchestrator/SKILL.md
@@ -18,20 +18,30 @@ description: 사용자가 "홈페이지 만들어줘" 등 단일 요청으로 �
 ### Phase 1. 기획 (Planning)
 - **위임 대상**: `mobile-web-planner`
 - **행동 지침**: 사용자의 요구사항을 전달하여, IA(Information Architecture)와 최소 3장 이상의 화면이 포함된 **스토리보드 HTML 및 Business Rules 마크다운**을 생성하도록 지시합니다.
-- **품질 게이트**: `python3 skills/mobile-web-planner/scripts/validate_storyboard.py` 가 `exit 0` 으로 통과해야만 Phase 2로 넘어갈 수 있습니다.
+- **품질 게이트**: 기획 스킬의 검증기 **셋 모두**가 `exit 0` 이어야 Phase 2로 넘어갑니다 — `validate_storyboard.py` · `check_badge_overflow.py` · `check_badge_alignment.py`. Chrome 을 쓸 수 있으면 `check_layout_runtime.py` 도 함께 확인합니다. 검증기 목록의 원본은 `mobile-web-planner` 의 SKILL.md 이며 여기에 규칙을 복제하지 않습니다.
 
 ### Phase 2. 구현 (Implementation)
 - **위임 대상**: `nextjs-implementer` (또는 프론트엔드 스택에 따라 `doksam-ui`, `react-expert`)
 - **행동 지침**: Phase 1에서 생성된 스토리보드 HTML과 Business Rules를 바탕으로 실제 코드를 스캐폴딩(Scaffolding)하고 구현하도록 지시합니다. (이슈 #139 참조: Next.js 또는 Vite+React 중 선택 지시)
 - **품질 게이트**: 빌드(`pnpm build`)가 성공하고 정적 에러가 없어야 Phase 3으로 넘어갑니다.
 
-### Phase 3. 보안 검증 (Security & Compliance) - *Pending (이슈 #138)*
-- **위임 대상**: `finguard` (추가 예정)
+### Phase 3. 보안 검증 (Security & Compliance)
+- **위임 대상**: `finguard`
 - **행동 지침**: 구현된 코드에 하드코딩된 시크릿 키나 개인정보(연락처, 배송지) 노출, XSS/SQLi 취약점이 없는지 스캔합니다.
-- **품질 게이트**: FinGuard 스캔 결과 취약점이 0건이어야 합니다. 취약점 발견 시 다시 Phase 2로 보내 자가 치유(Self-Healing)를 지시합니다.
+- **품질 게이트**: 게이트 래퍼(`skills/finguard/scripts/run_gate.py`)의 차단 심각도 finding 이 0건이어야 합니다. 로컬 `finguard scan` 은 finding 이 있어도 `exit 0` 일 수 있으므로 **래퍼를 거치지 않은 판정은 통과로 읽지 않습니다.**
+- 취약점 발견 시 Phase 2로 되돌려 수정을 지시하되, **재검증은 최대 3회**입니다. 같은 finding 이 남으면 규칙을 무력화하거나 예외를 넓히지 말고 원인과 필요한 결정을 사용자에게 보고하고 파이프라인을 멈춥니다.
+- 통과는 "탐지된 차단 대상 없음"이지 "취약점 없음"이 아닙니다. 스캔 범위와 한계를 최종 보고에 함께 적습니다.
 
 ### Phase 4. 로컬 기동 및 배포 (Deploy & Run)
-- **행동 지침**: 모든 게이트를 통과하면, 개발 서버(`pnpm dev`)를 백그라운드에서 기동시키고, 사용자에게 결과물 확인 URL(예: `http://localhost:3000`)을 안내합니다.
+- **행동 지침**: 모든 게이트를 통과하면 개발 서버를 기동하고 **응답을 확인한 뒤** 사용자에게 URL 을 안내합니다. 기동 판정은 스크립트가 합니다.
+
+  ```sh
+  python3 skills/nextjs-implementer/scripts/serve_and_check.py \
+    --cmd "pnpm dev -- --port {port}" --dir <프로젝트> --port 3000 --route / --keep
+  ```
+
+- **관례 포트를 그대로 안내하지 않습니다.** 3000·5173 이 이미 점유돼 있으면 프레임워크는 조용히 다른 포트로 옮겨 가므로, 스크립트가 **확정한 포트**만 전달합니다. 프로세스 생존은 기동의 증거가 아닙니다.
+- 배포는 이 파이프라인의 자동 단계가 아닙니다. 사용자 승인과 프로젝트의 배포 절차를 따릅니다.
 
 ## 경계 및 위임 원칙 (Trigger Boundaries)
 - **기획을 묻는다면**: 이 스킬이 아니라 `mobile-web-planner`가 직접 응답하게 둡니다.
@@ -39,6 +49,10 @@ description: 사용자가 "홈페이지 만들어줘" 등 단일 요청으로 �
 - **본 스킬의 발동 조건**: 사용자가 명시적으로 "파이프라인 돌려줘", "처음부터 끝까지 다 만들어줘", "sdlc-orchestrator 실행" 과 같이 **E2E(End-to-End) 전체 제작**을 요구할 때만 전면에 나섭니다.
 
 ## 완료 조건 (Definition of Done)
-1. 기획 산출물 검증기(`validate_storyboard.py`) 통과
-2. 코드 빌드 및 로컬 구동 테스트 성공
-3. 사용자에게 최종 브라우저 접속 주소를 브리핑하며 파이프라인 종료를 선언함
+1. 기획 산출물 검증기가 모두 `exit 0`
+2. 코드 빌드 통과, 화면 ID 추적표에 미구현 화면 없음
+3. 보안 게이트(`run_gate.py`)의 차단 finding 0건, 또는 남은 건마다 근거와 필요한 결정이 보고에 명시됨
+4. `serve_and_check.py` 가 `exit 0` 이고, **확정된 포트**의 URL 을 사용자에게 전달함
+5. 각 단계에서 건너뛴 것과 잔여 위험(추측으로 채운 값, mock 으로 남긴 경로)이 최종 보고에 있음
+
+단계별 입출력과 중단 조건의 원본은 `skills/finguard/references/ai-sdlc.md` 입니다. 그 표와 어긋나면 원본이 옳습니다.

--- a/tests/test_referenced_paths.py
+++ b/tests/test_referenced_paths.py
@@ -1,0 +1,74 @@
+"""스킬 문서가 가리키는 경로가 실제로 존재하는지 검사한다 (stdlib only).
+
+문서는 "이 스크립트를 돌려라" 라고 지시하지만, 경로가 틀리거나 파일이 옮겨
+가면 **에이전트는 오류를 보고하지 않고 그 단계를 조용히 건너뛴다.** 게이트가
+있다고 믿는 상태가 게이트가 없는 상태보다 나쁘다 — sdlc-orchestrator 가
+finguard 를 "추가 예정" 으로 적어 둔 채 머지된 것이 그 예다.
+
+세 가지 표기를 모두 본다.
+
+    skills/<skill>/scripts/x.py     저장소 루트 기준
+    <스킬경로>/scripts/x.py          그 문서를 소유한 스킬 기준
+    <other-스킬경로>/scripts/x.py    이름이 박힌 다른 스킬 기준
+"""
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS = REPO / "skills"
+
+REPO_ROOTED = re.compile(r"\bskills/([a-z0-9-]+)/([A-Za-z0-9_/.-]+\.(?:py|js|md|html))")
+OWN_SKILL = re.compile(r"<스킬경로>/([A-Za-z0-9_/.-]+\.(?:py|js))")
+NAMED_SKILL = re.compile(r"<(?:설치된-)?([a-z0-9-]+?)-스킬(?:경로)?>/([A-Za-z0-9_/.-]+\.(?:py|js))")
+MD_LINK = re.compile(r"\]\((references/[A-Za-z0-9_.-]+\.md)\)")
+
+
+def docs():
+    for path in sorted(SKILLS.rglob("*.md")):
+        # 픽스처는 산출물 예시라 문서가 아니다.
+        if "tests/fixtures" in path.as_posix():
+            continue
+        yield path
+
+
+def owning_skill(path):
+    return SKILLS / path.relative_to(SKILLS).parts[0]
+
+
+class TestReferencedPaths(unittest.TestCase):
+    def test_all_referenced_paths_exist(self):
+        missing = []
+        for doc in docs():
+            text = doc.read_text(encoding="utf-8")
+            skill_dir = owning_skill(doc)
+            targets = []
+            targets += [SKILLS / skill / rest for skill, rest in REPO_ROOTED.findall(text)]
+            targets += [skill_dir / rest for rest in OWN_SKILL.findall(text)]
+            targets += [SKILLS / skill / rest for skill, rest in NAMED_SKILL.findall(text)]
+            targets += [doc.parent / rest for rest in MD_LINK.findall(text)]
+            for target in targets:
+                if not target.exists():
+                    missing.append(f"{doc.relative_to(REPO)} → {target.relative_to(REPO)}")
+        self.assertEqual(missing, [], "문서가 없는 경로를 가리킨다:\n" + "\n".join(missing))
+
+    def test_pipeline_gates_are_not_left_as_todo(self):
+        """이미 존재하는 스킬을 '추가 예정' 으로 적어 두지 않는다.
+
+        오케스트레이터가 게이트를 미구현으로 적어 두면 그 단계가 통째로
+        비활성 상태로 머지되고, 파이프라인은 검증했다고 보고한다.
+        """
+        existing = {path.name for path in SKILLS.iterdir() if path.is_dir()}
+        for doc in docs():
+            text = doc.read_text(encoding="utf-8")
+            for name in existing:
+                pattern = re.compile(
+                    rf"`{re.escape(name)}`[^\n]*\((?:추가 예정|미구현|TODO)\)")
+                with self.subTest(doc=str(doc.relative_to(REPO)), skill=name):
+                    self.assertIsNone(
+                        pattern.search(text),
+                        f"{doc.relative_to(REPO)} 가 이미 있는 스킬 {name} 를 미구현으로 적었다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
머지된 `sdlc-orchestrator`(#142)가 저장소의 현재 상태와 어긋나 있어 맞춘다. 세 군데 모두 **파이프라인이 검증을 건너뛰고 완료를 선언하게 되는** 종류다.

## 무엇이 어긋났나

| 단계 | 문서가 말하던 것 | 실제 |
|---|---|---|
| Phase 3 보안 | `finguard` **(추가 예정)** — 단계 전체가 Pending | `skills/finguard/` 와 게이트 래퍼 `run_gate.py` 가 이미 main 에 있다 |
| Phase 4 기동 | `pnpm dev` 띄우고 `localhost:3000` 안내 | 이슈 #138 에서 고친 실패 모드 그대로다 — 포트가 점유되면 프레임워크가 조용히 옮겨 가 안내한 URL 이 틀려진다 |
| Phase 1 기획 | 검증기 1개(`validate_storyboard.py`)만 게이트 | 기획 스킬은 3개(+브라우저 검사)를 완료 조건으로 요구한다 |

Phase 3 에는 게이트 래퍼를 쓰는 이유(로컬 `scan` 은 finding 이 있어도 `exit 0` 일 수 있다), 재검증 3회 상한, "탐지된 차단 대상 없음 ≠ 취약점 없음" 도 함께 적었다. 규칙 원본은 각 스킬과 `finguard/references/ai-sdlc.md` 이며 여기에 복제하지 않는다.

## 드리프트를 막는 테스트

`tests/test_referenced_paths.py` — 저장소의 **모든 스킬 문서**에 대해 두 가지를 본다.

1. 문서가 가리키는 스크립트·reference 가 실제로 존재하는가 (`skills/x/y.py`, `<스킬경로>/scripts/y.py`, `<other-스킬경로>/scripts/y.py`, `(references/z.md)` 네 표기 모두)
2. **이미 있는 스킬을 "추가 예정"·"미구현"·TODO 로 적지 않았는가**

경로가 틀리거나 단계가 미구현으로 적혀 있으면 에이전트는 오류를 내지 않고 그 단계를 조용히 건너뛴다. **게이트가 있다고 믿는 상태가 게이트가 없는 상태보다 나쁘다.**

통과만 확인하면 무의미하므로, 수정 전 파일(`origin/main` 버전)로 되돌려 실제로 실패하는 것을 확인했다.

```
FAIL: test_pipeline_gates_are_not_left_as_todo (doc='skills/sdlc-orchestrator/SKILL.md', skill='finguard')
AssertionError: match='`finguard` (추가 예정)' ... 이미 있는 스킬 finguard 를 미구현으로 적었다
```

## 검증

```
./scripts/run_tests.sh   # 전부 통과
```

관련: #138 (보안 게이트), #142 (오케스트레이터 도입)
